### PR TITLE
Updates to support offline conditions db usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,19 @@ add_custom_command(OUTPUT ${CMAKE_INSTALL_PREFIX}/share/fieldmaps/BmapCorrected3
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/hps-fieldmaps/)
 add_custom_target(hps_fieldmaps_install ALL DEPENDS hps_fieldmaps_download ${CMAKE_INSTALL_PREFIX}/share/fieldmaps/BmapCorrected3D_13k_unfolded_scaled_1.15384615385.dat)
 
+# checkout conditions files for installing locally
+add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/hps-conditions-backup/
+    COMMAND git clone https://github.com/JeffersonLab/hps-conditions-backup.git
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_custom_target(hps_conditions_download ALL DEPENDS ${CMAKE_BINARY_DIR}/hps-conditions-backup/)
+
+# decompress conditions db and copy to install dir
+add_custom_command(OUTPUT ${CMAKE_INSTALL_PREFIX}/share/hps_conditions.db
+    COMMAND tar -zxvf hps_conditions.db.tar.gz
+    COMMAND cp hps_conditions.db ${CMAKE_INSTALL_PREFIX}/share
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/hps-conditions-backup/)
+add_custom_target(hps_conditions_install ALL DEPENDS hps_conditions_download ${CMAKE_INSTALL_PREFIX}/share/hps_conditions.db)
+
 # clone LCIO from github
 set(LCIO_TAG v02-07-04)
 set(LCIO_VERSION 2.7.4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ add_custom_target(lcio_download ALL DEPENDS ${CMAKE_BINARY_DIR}/LCIO)
 
 # build LCIO java lib
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/LCIO/target/lcio-${LCIO_VERSION}-SNAPSHOT-bin.jar
-    COMMAND mvn ARGS -Dmaven.repo.local=${M2REPO} -DskipTests -q
+    COMMAND mvn ARGS -Dmaven.repo.local=${M2REPO} -DskipTests -q install
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/LCIO)
 add_custom_target(lcio_java_build ALL DEPENDS lcio_download ${CMAKE_BINARY_DIR}/LCIO/target/lcio-${LCIO_VERSION}-SNAPSHOT-bin.jar)
 


### PR DESCRIPTION
Supports offline conditions db usage as implemented in

https://github.com/JeffersonLab/hps-java/pull/322

That should be merged before this.

Adds option to JobManager and FilterMCBunches for using offline conditions db:

```
job_manager.use_offline_conditions_db = True
```

Tested that this works now for filtering and readout using a build of hps-java from iss320 branch.

When building hps-mc, you will have to type in a github username and password during the build procedures to download the hps-conditions-backup project (it is private and only accessible to HPS collaboration members).