### PR TITLE
Iss143: Fixed some issues in stdhep tools:

### DIFF
--- a/scripts/print_mvn_project_version.py
+++ b/scripts/print_mvn_project_version.py
@@ -7,4 +7,4 @@ tree = ET.parse(sys.argv[1])
 root = tree.getroot()
 for child in root:
     if "version" in child.tag[child.tag.rfind('}')+1:]:
-        print child.text
+        print(child.text)

--- a/tools/stdhep-lib/src/src/inc/stdhep_mcfio.h
+++ b/tools/stdhep-lib/src/src/inc/stdhep_mcfio.h
@@ -32,7 +32,9 @@ extern "C" {
 
 
 int StdHepXdrReadInit(char *filename, int ntries, int ist);
+int StdHepXdrReadInitNTries(char *filename, int  *ntries, int ist);
 int StdHepXdrReadOpen(char *filename, int ntries, int ist);
+int StdHepXdrReadOpenNTries(char *filename, int *ntries, int ist);
 int StdHepXdrRead(int *ilbl, int ist);
 int StdHepXdrReadMulti(int *ilbl, int ist);
 int StdHepXdrWriteInit(char *filename, char *title, int ntries, int ist);

--- a/tools/stdhep-lib/src/src/stdhep/stdhep_mcfio.c
+++ b/tools/stdhep-lib/src/src/stdhep/stdhep_mcfio.c
@@ -74,6 +74,14 @@ int StdHepXdrReadInit(char *filename, int ntries, int ist)
     ierr = StdHepXdrReadOpen(filename, ntries, ist);
     return ierr;
 }
+int StdHepXdrReadInitNTries(char *filename, int  *ntries, int ist)
+{
+    int ierr;
+
+    mcfioC_Init();
+    ierr = StdHepXdrReadOpenNTries(filename, ntries, ist);
+    return ierr;
+}
 int StdHepXdrReadOpen(char *filename, int ntries, int ist)
 {
     int istream, iblk;
@@ -88,7 +96,7 @@ int StdHepXdrReadOpen(char *filename, int ntries, int ist)
     mcfioC_InfoStreamChar(istream, MCFIO_CREATIONDATE, stdhd1_.date, &stdhd2_.dlen);
     mcfioC_InfoStreamChar(istream, MCFIO_TITLE, stdhd1_.title, &stdhd2_.tlen);
     mcfioC_InfoStreamChar(istream, MCFIO_COMMENT, stdhd1_.comment, &stdhd2_.clen);
-    mcfioC_InfoStreamInt(istream, MCFIO_NUMEVTS, &ntries);
+    mcfioC_InfoStreamInt(istream, MCFIO_NUMEVTS,  &ntries);
     mcfioC_InfoStreamInt(istream, MCFIO_NUMBLOCKS, &numblocks);
     mcfioC_InfoStreamInt(istream, MCFIO_BLOCKIDS, blkids);
 
@@ -104,6 +112,39 @@ int StdHepXdrReadOpen(char *filename, int ntries, int ist)
     fprintf(stdout,"          title: %s\n",stdhd1_.title);
     fprintf(stdout,"          date: %s\n",stdhd1_.date);
     fprintf(stdout,"                    %d events\n",ntries);
+    fprintf(stdout,"                    %d blocks per event\n",stdhd2_.numblocks);
+    return 0;
+}
+int StdHepXdrReadOpenNTries(char *filename, int *ntries, int ist)
+{
+    int istream, iblk;
+    int numblocks, blkids[50];
+
+    istream =  mcfioC_OpenReadDirect(filename);
+    stdstr_.ixdrstr[ist] = istream;
+    if (istream == -1) {
+        fprintf(stderr," StdHepXdrReadOpen: cannot open output file \n");
+        return -1;
+        }
+    mcfioC_InfoStreamChar(istream, MCFIO_CREATIONDATE, stdhd1_.date, &stdhd2_.dlen);
+    mcfioC_InfoStreamChar(istream, MCFIO_TITLE, stdhd1_.title, &stdhd2_.tlen);
+    mcfioC_InfoStreamChar(istream, MCFIO_COMMENT, stdhd1_.comment, &stdhd2_.clen);
+    mcfioC_InfoStreamInt(istream, MCFIO_NUMEVTS,  ntries);
+    mcfioC_InfoStreamInt(istream, MCFIO_NUMBLOCKS, &numblocks);
+    mcfioC_InfoStreamInt(istream, MCFIO_BLOCKIDS, blkids);
+
+    stdhd2_.numblocks = numblocks;
+    for ( iblk=0; iblk < numblocks; ++iblk ) {
+        stdhd2_.blkids[iblk] = blkids[iblk];
+    }
+
+    stdcnt_.nstdrd = 0;
+    stdcnt_.nlhrd = 0;
+    fprintf(stdout,
+       " StdHepXdrReadOpen: successfully opened input stream %d\n",istream);
+    fprintf(stdout,"          title: %s\n",stdhd1_.title);
+    fprintf(stdout,"          date: %s\n",stdhd1_.date);
+    fprintf(stdout,"                    %d events\n",*ntries);
     fprintf(stdout,"                    %d blocks per event\n",stdhd2_.numblocks);
     return 0;
 }

--- a/tools/stdhep-tools/CMakeLists.txt
+++ b/tools/stdhep-tools/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 
 project(stdhep-tools)
 
+add_definitions(-std=c++11)
+
 file(COPY ${PROJECT_SOURCE_DIR}/src/ DESTINATION ${CMAKE_BINARY_DIR}/stdhep-tools-src/)
 
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/stdhep-tools-src/bin)
@@ -9,6 +11,7 @@ file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/stdhep-tools-src/bin)
 set(STDHEP_TOOLS_BIN_DIR ${CMAKE_BINARY_DIR}/stdhep-tools-src/bin)
 
 file(GLOB stdhep_program_sources ${PROJECT_SOURCE_DIR}/src/*.cc)
+
 foreach (stdhep_program_source ${stdhep_program_sources})
     get_filename_component(stdhep_program ${stdhep_program_source} NAME_WE)
     message(STATUS "Configuring StdHep tool: ${stdhep_program}")

--- a/tools/stdhep-tools/CMakeLists.txt
+++ b/tools/stdhep-tools/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.0)
 
 project(stdhep-tools)
 
-add_definitions(-std=c++11)
-
 file(COPY ${PROJECT_SOURCE_DIR}/src/ DESTINATION ${CMAKE_BINARY_DIR}/stdhep-tools-src/)
 
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/stdhep-tools-src/bin)

--- a/tools/stdhep-tools/src/Makefile
+++ b/tools/stdhep-tools/src/Makefile
@@ -8,7 +8,7 @@ LOADLIBS=-L$(STDHEP_DIR)/lib
 LDLIBS=-lstdhepC -lFmcfio -lgsl -lgslcblas
 INCFILES=-I$(STDHEP_DIR)/src/inc -I$(SRC_DIR)
 CPP=g++
-CPPFLAGS=$(LOADLIBS) $(LDLIBS) -g
+CPPFLAGS=$(LOADLIBS) $(LDLIBS) -g -std=c++11
 TARGETS := $(patsubst $(SRC_DIR)/%.cc,$(BIN)/%,$(wildcard $(SRC_DIR)/*.cc))
 UTIL_SRC := $(wildcard $(SRC_DIR)/*.cpp)
 UTIL_OBJ := $(UTIL_SRC:.cpp=.o)

--- a/tools/stdhep-tools/src/random_sample.cc
+++ b/tools/stdhep-tools/src/random_sample.cc
@@ -9,37 +9,44 @@
 
 #include <unistd.h>
 
+#include <random>       // std::default_random_engine
+#include <algorithm>    // std::shuffle
+#include <iostream>
+using namespace std;
+
 // takes input stdhep files, merges a Poisson-determined number of events per event into a new stdhep file
 int main(int argc,char** argv)
 {
-	int nevhep;             /* The event number */
-	vector<stdhep_entry> new_event;
-
-	vector<vector<stdhep_entry> *> input_events;
-
 	double poisson_mu = -1.0;
+        double poisson_mu_correction = 0; // correction parameter for mu of Poisson
 	int output_n = 500000;
 	int max_output_files = 1;
 	int output_filename_digits = 1;
+        int n_events_per_batch = 1000000;
 
 	int rseed = 0;
 
 	int c;
 
-	while ((c = getopt(argc,argv,"hn:m:N:s:")) !=-1)
+	while ((c = getopt(argc,argv,"hn:m:t:N:b:s:")) !=-1)
 		switch (c)
 		{
 			case 'h':
 				printf("-h: print this help\n");
 				printf("-m: mean number of events in an event\n");
+                                printf("-t: corretion parameter for mu\n");
 				printf("-N: max number of files to write\n");
-				printf("-n: output events per output file\n");
+				printf("-b: number of events per batch for caching input events\n");
+                                printf("-n: o\n");
 				printf("-s: RNG seed\n");
 				return(0);
 				break;
 			case 'm':
 				poisson_mu = atof(optarg);
 				break;
+                        case 't':
+                                poisson_mu_correction = atof(optarg);
+                                break;
 			case 'n':
 				output_n = atoi(optarg);
 				break;
@@ -75,7 +82,6 @@ int main(int argc,char** argv)
 	gsl_rng_set(r,rseed);
 
 
-	int n_events;
 	int istream = 0;
 	int ostream = 1;
 	int ilbl;
@@ -85,52 +91,105 @@ int main(int argc,char** argv)
 	char output_filename[100];
 	int file_n = 1;
 
-	open_read(argv[optind++],istream);
+        int n_events=0;
+        int input_ind=optind;
+        while(input_ind<argc-1){
+                n_events += open_read(argv[input_ind++],istream);
+                close_read(istream);
+        }
+        printf("read %d events\n",n_events);
 
-	while (true) {
-		bool no_more_data = false;
-		while (!read_next(istream)) {
-			close_read(istream);
-			if (optind<argc-1)
-			{
-				open_read(argv[optind++],istream);
+        if (poisson_mu<0) {
+                poisson_mu = ((double) n_events)/output_n*(1-poisson_mu_correction);
+                printf("Setting mu to %f\n",poisson_mu);
+        }
+
+        
+        int n_batches = n_events/n_events_per_batch + 1;
+	printf("Number of batches for caching: %d\n", n_batches);
+	
+        vector<stdhep_entry> new_event;
+        vector<vector<stdhep_entry> *> input_events;
+	vector<int> event_list;
+	int batch_num = 0;
+	int n_events_used = 0;
+	int event_num = 0;
+	int nevhep = 0;
+	vector<vector<stdhep_entry> *> events_no_used;
+
+        while (file_n<=max_output_files) {
+                sprintf(output_filename,"%s_%0*d.stdhep",output_basename,output_filename_digits,file_n++);
+                open_write(output_filename,ostream,output_n);
+		nevhep = 0; 
+		input_ind = optind;
+      	  	open_read(argv[input_ind++],istream);
+	        while (true) {
+        	        bool no_more_data = false;
+                	while (!read_next(istream)) {
+                       		close_read(istream);
+				if (input_ind<argc-1)
+					open_read(argv[input_ind++],istream);
+				else
+				{
+					no_more_data = true;
+					break;
+                        	}
+                	}
+			if(!no_more_data){
+				vector<stdhep_entry> *read_event = new vector<stdhep_entry>;
+				read_stdhep(read_event);
+                		input_events.push_back(read_event);
+				event_list.push_back(event_num++);
 			}
-			else
-			{
-				no_more_data = true;
-				break;
-			}
-		}
-		if (no_more_data) break;
+			if( ((input_events.size() == n_events_per_batch) && (batch_num < n_batches - 1)) || (no_more_data && (batch_num == n_batches - 1)) ){
+				batch_num++;
+				shuffle(event_list.begin(), event_list.end(), default_random_engine(rseed + 10));
+				int event_list_index = 0;
+				while (nevhep < output_n){
+					int n_merge = gsl_ran_poisson(r,poisson_mu);
+					if (n_merge==0)
+						add_filler_particle(&new_event);
+					else{
+						if(event_list_index + n_merge > event_list.size()){
+							if(batch_num == n_batches){
+								for(int i = 0; i < input_events.size();i++)
+									delete input_events[i];
+								input_events.clear();
+								event_list.clear();
+							}
+							else{
+								n_events_used += event_list_index;
+                                        	                for(int i = 0; i<event_list_index;i++)
+                                                	                delete input_events[event_list[i]];
+								events_no_used.clear();
+								for(int i = event_list_index; i < event_list.size(); i++)
+									events_no_used.push_back(input_events[event_list[i]]);
+								input_events.clear();
+								event_list.clear();
+								event_num = 0;
+								for(int i = 0; i< events_no_used.size(); i++){
+									input_events.push_back(events_no_used[i]);
+									event_list.push_back(event_num++);
+								}
+							}
+							break;
+						}
+						else{
+							for (int i=0;i<n_merge;i++)
+								append_stdhep(&new_event, input_events[event_list[event_list_index + i]]);		
 
-		vector<stdhep_entry> * read_event = new vector<stdhep_entry>;
-		read_stdhep(read_event);
-		input_events.push_back(read_event);
-	}
-
-	printf("read %d events\n",input_events.size());
-
-	if (poisson_mu<0) {
-		poisson_mu = ((double) input_events.size())/output_n;
-		printf("Setting mu to %f\n",poisson_mu);
-	}
-
-	while (file_n<=max_output_files) {
-		sprintf(output_filename,"%s_%0*d.stdhep",output_basename,output_filename_digits,file_n++);
-		open_write(output_filename,ostream,output_n);
-		for (int nevhep = 0; nevhep < output_n; nevhep++)
-		{
-			int n_merge = gsl_ran_poisson(r,poisson_mu);
-			if (n_merge==0)
-				add_filler_particle(&new_event);
-			for (int i=0;i<n_merge;i++)
-			{
-				int random_index = gsl_rng_uniform_int(r,input_events.size());
-				append_stdhep(&new_event,input_events[random_index]);
-			}
-
-			write_stdhep(&new_event,nevhep+1);
-			write_file(ostream);
+							event_list_index += n_merge;							
+						}
+					}
+					write_stdhep(&new_event,++nevhep);
+					write_file(ostream);
+				}
+				if(nevhep == output_n){
+					close_write(ostream);
+					break;
+				}
+			} 
+	                if (no_more_data) break;
 		}
 		close_write(ostream);
 	}

--- a/tools/stdhep-tools/src/random_sample_usingInputEventsInOrder.cc
+++ b/tools/stdhep-tools/src/random_sample_usingInputEventsInOrder.cc
@@ -1,0 +1,129 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+#include <stdhep_util.hh>
+
+#include <gsl/gsl_rng.h>
+#include <gsl/gsl_randist.h>
+
+#include <unistd.h>
+#include <iostream>
+using namespace std;
+
+// takes input stdhep files, merges a Poisson-determined number of events per event into a new stdhep file
+int main(int argc,char** argv)
+{
+	double poisson_mu = -1; // # of electrons per bunch
+        double poisson_mu_correction = 0; // correction parameter for mu of Poisson
+	int output_n = 2500000;
+	int output_filename_digits = 1;
+
+	int rseed = 0;
+
+	int c;
+
+	while ((c = getopt(argc,argv,"hn:m:t:s:")) !=-1)
+		switch (c)
+		{
+			case 'h':
+				printf("-h: print this help\n");
+				printf("-m: mean number of events in an event\n");
+                                printf("-t: corretion parameter for mu\n");
+				printf("-n: output events per output file\n");
+				printf("-s: RNG seed\n");
+				return(0);
+				break;
+			case 'm':
+				poisson_mu = atof(optarg);
+				break;
+                        case 't':
+                                poisson_mu_correction = atof(optarg);
+                                break;
+			case 'n':
+				output_n = atoi(optarg);
+				break;
+			case 's':
+				rseed = atoi(optarg);
+				break;
+			case '?':
+				printf("Invalid option or missing option argument; -h to list options\n");
+				return(1);
+			default:
+				abort();
+		}
+
+	printf("Mean events per output event %f, output events per output file %d\n",poisson_mu,output_n);
+
+	if ( argc-optind <2 )
+	{
+		printf("<input stdhep filenames> <output stdhep basename>\n");
+		return 1;
+	}
+
+	//initialize the RNG
+	const gsl_rng_type * T;
+	gsl_rng * r;
+	gsl_rng_env_setup();
+
+	T = gsl_rng_mt19937;
+	r = gsl_rng_alloc (T);
+	gsl_rng_set(r,rseed);
+
+
+	int istream = 0;
+	int ostream = 1;
+	int ilbl;
+
+
+	char *output_basename = argv[argc-1];
+	char output_filename[100];
+
+        int n_events=0;
+        int mark_optind=optind;
+	while(optind<argc-1){
+		n_events += open_read(argv[optind++],istream);
+                close_read(istream);
+        }
+        printf("read %d events\n",n_events);
+
+        if (poisson_mu<0) {
+                poisson_mu = ((double) n_events)/output_n*(1-poisson_mu_correction);
+                printf("Setting mu to %f\n",poisson_mu);
+        }
+
+        vector<stdhep_entry> new_event;
+        open_read(argv[mark_optind++],istream);
+	sprintf(output_filename,"%s_%0*d.stdhep",output_basename,output_filename_digits, 1);
+	open_write(output_filename,ostream,output_n);
+	for (int nevhep = 0; nevhep < output_n; nevhep++)
+	{
+		int n_merge = gsl_ran_poisson(r,poisson_mu);
+		if (n_merge==0)
+			add_filler_particle(&new_event);
+
+                for (int i=0;i<n_merge;i++)
+                {
+                        while (!read_next(istream)) {
+                                close_read(istream);
+                                if (mark_optind<argc-1)
+                                {
+                                        open_read(argv[mark_optind++],istream);
+                                }
+                                else
+                                {
+                                        printf("Out of input events\n");
+                                        close_write(ostream);
+                                        return(0);
+                                }
+                        }
+
+                        read_stdhep(&new_event);
+                }
+
+		write_stdhep(&new_event,nevhep+1);
+		write_file(ostream);
+	}
+	close_write(ostream);
+}
+

--- a/tools/stdhep-tools/src/stdhep_mcfio.h
+++ b/tools/stdhep-tools/src/stdhep_mcfio.h
@@ -32,7 +32,9 @@ extern "C" {
 
 
 int StdHepXdrReadInit(char *filename, int ntries, int ist);
+int StdHepXdrReadInitNTries(char *filename, int  *ntries, int ist);
 int StdHepXdrReadOpen(char *filename, int ntries, int ist);
+int StdHepXdrReadOpenNTries(char *filename, int *ntries, int ist);
 int StdHepXdrRead(int *ilbl, int ist);
 int StdHepXdrReadMulti(int *ilbl, int ist);
 int StdHepXdrWriteInit(char *filename, char *title, int ntries, int ist);


### PR DESCRIPTION
1) Issue for a memory leak. This was causing issues running on large files.
2) Issue with fie open not returning the number of events properly.
3) Issue of random_sample.cc - 
            i) random_sample.cc reads in all the input into a vector. This takes a lot of memory.
            ii) random_sample.cc picks the input events at random. This means that an estimate of 37% input events are not used, and 37% are used more than once.
                        a) Solution1: random_sample_usingInputEventsInOrder.cc  – Just takes the events in order, avoiding the memory issue and the usage issue.
                        b) Solution2: Update of random_sample.cc  – Use the std::shuffle to randomize the order of the events. No waste of electrons, and less memory use.