### PR TITLE
Update to use ConfigParser

### DIFF
--- a/python/hpsmc/component.py
+++ b/python/hpsmc/component.py
@@ -74,16 +74,22 @@ class Component:
     def cleanup(self):
         pass    
 
+    def config(self, section_name):
+        if config.parser.has_section(section_name):
+            for name, value in config.parser.items(section_name):
+                setattr(self, name, value)
+                logger.info("%s=%s" % (name, value))
+
     def config(self):
         """
-        Automatically load attributes from config file(s)
+        Automatically load attributes from config section
         """
         logger.info("Configuring '%s'" % self.name)
         section_name = self.__class__.__name__
         logger.info("Loading config for '%s'" % section_name)
         if config.parser.has_section(section_name):
-            section = config.parser[section_name]
-            for name, value in section.items():
+#            section = config.parser[section_name]
+            for name, value in config.parser.items(section_name):
                 setattr(self, name, value)
                 logger.info("%s=%s" % (name, value))
                 

--- a/python/hpsmc/config.py
+++ b/python/hpsmc/config.py
@@ -1,8 +1,11 @@
-import os, logging, configparser
+import os, logging
+
+logger = logging.getLogger("hpsmc.config")
+logger.setLevel(logging.DEBUG)
 
 from os.path import expanduser
 
-logger = logging.getLogger("hpsmc.config")
+import ConfigParser as configparser
 
 config_files = [expanduser("~") + os.sep + ".hpsmc", ".hpsmc"]
 
@@ -10,14 +13,15 @@ config_files = [expanduser("~") + os.sep + ".hpsmc", ".hpsmc"]
 try:
     parser
 except:
-    parser = configparser.ConfigParser()    
-    logger.info("Reading config from: %s" % str(config_files))
+    parser = configparser.ConfigParser()
+    logger.debug("Reading config from: %s" % str(config_files))
     parser.read(config_files)
-    #print("Read config items...")
-    #for section in parser.items():
-    #    for item in section:
-    #        print(item)
-    logger.info("Done parsing config!")
+    for section in parser.sections():
+        logger.debug("[" + section + "]")        
+        for i,v in parser.items(section): 
+            logger.debug("%s=%s" % (i, v))
+                              
+    logger.debug("Done parsing config!")
 
 # Load from a non-default file location
 def load(self, path):

--- a/python/hpsmc/generators.py
+++ b/python/hpsmc/generators.py
@@ -77,8 +77,11 @@ class StdHepConverter(EGS5):
     def __init__(self, **kwargs):
         self.name = "lhe_v1"
         EGS5.__init__(self, **kwargs)
+  
+    def config(self):
+        self.config("EGS5")
 
-    def setup(self):
+    def setup(self):    
         EGS5.setup(self)
         if not len(self.inputs):
             raise Exception("Missing required input LHE file.")                    
@@ -289,7 +292,7 @@ class MG5(EventGenerator):
         logger.info("MG5 - Executing '%s' from '%s'" % (self.name, os.getcwd()))
         Component.execute(self, log_out, log_err)
         
-        lhe_files = glob.glob(os.path.join(self.rundir, self.proc_dir, "Events", self.name, "*.lhe.gz"))
+        lhe_files = glob.glob(os.path.join(self.rundir, self.proc_dir, "Events", "*", "*.lhe.gz"))
         for f in lhe_files:            
             logger.info("MG5 - Copying '%s' to '%s'" % (f, self.rundir))
             shutil.copyfile(f, os.path.join(self.rundir, self.name + "_" + os.path.basename(f)))

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -157,10 +157,10 @@ class JobManager(Component):
             logger.info("setting conditions_user from config: %s" % self.conditions_user)
             self.args.append("-Dorg.hps.conditions.user=%s" % self.conditions_user)
         if hasattr(self, "conditions_password"):
-            logger.info("setting conditions password from config (not shown)")
+            logger.info("setting conditions_password from config (not shown)")
             self.args.append("-Dorg.hps.conditions.password=%s" % self.conditions_password)
         if hasattr(self, "conditions_url"):
-            logger.info("setting conditions url from config: %s" % self.conditions_url)
+            logger.info("setting conditions_url from config: %s" % self.conditions_url)
             self.args.append("-Dorg.hps.conditions.url=%s" % self.conditions_url)
         self.args.append("-jar")
         self.args.append(self.hps_java_bin_jar)


### PR DESCRIPTION
- Update to use ConfigParser instead of configparser
- Add method to Component for loading from alternate config section name
- Change some log messages during setup and config to debug level from info
- Fix wildcard copying in MG for generated LHE file names (makes wildcard more generic)
- Add an `-s` switch to Job for specifying job steps (was none before - same as `--job-steps`)
- Do not copy input files when running in dry run mode