### PR TITLE
Iss145: Add preliminary support for hpstr

### DIFF
--- a/python/jobs/hpstr_job.py
+++ b/python/jobs/hpstr_job.py
@@ -21,6 +21,7 @@ else:
     outfiles = params.output_files
 
 hpstr = HPSTR(cfg="recoTuple_cfg.py",
+              run_mode=params.run_mode,
               inputs=infiles,
               outputs=outfiles)
 

--- a/python/jobs/hpstr_job.py
+++ b/python/jobs/hpstr_job.py
@@ -1,0 +1,29 @@
+from hpsmc.job import Job
+from hpsmc.tools import HPSTR 
+
+# Initialize the job.
+job = Job(name="HPSTR job")
+job.initialize()
+
+params = job.params
+input_files = params.input_files
+output_files = params.output_files
+
+# Figure out input and output file lists depending on whether 
+# JSON data is a dict or list.
+if isinstance(params.input_files, dict):
+    infiles = params.input_files.keys()
+else:
+    infiles = params.input_files
+if isinstance(params.output_files, dict):
+    outfiles = params.output_files.keys()
+else:
+    outfiles = params.output_files
+
+hpstr = HPSTR(cfg="recoTuple_cfg.py",
+              inputs=infiles,
+              outputs=outfiles)
+
+job.components.append(hpstr)
+
+job.run()


### PR DESCRIPTION
This PR adds support for the hpstr tool.

Tested with this sample job.json file:

```
{
    "run_mode": 0,
    "input_files": ["/work/slac/data/tritrigv2-beamv6_2500kBunches_HPS-PhysicsRun2016-Pass2_v4_5_0_pairs1_135.slcio"],
    "output_files": ["events.root"],
    "output_dir": "output",
    "nevents": 100
}
```

Ran sample hps-mc job using:

```
python python/jobs/hpstr_job.py -c .hpsmc ./job.json
```

hpstr requires the following config to be set:

```
[HPSTR]
hpstr_install_dir = /work/slac/hpstr/install
hpstr_base = /work/slac/hpstr
```

...where `hpstr_install_dir` points to the installation directory and `hpstr_base` points to the project directory.

The python config must be present in the `processors/config` dir of the `hpstr_base` directory.

The `nevents` argument to hpstr is not supported for now as passing `-n` to the binary was giving me an error message.