### PR TITLE
Update Madgraph fortran flags and call python2 instead of python

### DIFF
--- a/examples/tritrig_gen/job.json
+++ b/examples/tritrig_gen/job.json
@@ -3,7 +3,7 @@
     "run_params": "1pt05",
     "target_z": -5.0,
     "output_files": {
-        "tritrig_events.lhe.gz": "tritrig_recon_1.stdhep"
+        "tritrig_events.lhe.gz": "tritrig_1.stdhep"
     },
     "output_dir": "output"
 }

--- a/generators/madgraph5/src/BH/SubProcesses/makefile
+++ b/generators/madgraph5/src/BH/SubProcesses/makefile
@@ -1,5 +1,5 @@
 include ../../Source/make_opts
-FFLAGS+= -w
+FFLAGS+= -w -std=legacy
 
 # Definitions
 

--- a/generators/madgraph5/src/BH/bin/generate_events
+++ b/generators/madgraph5/src/BH/bin/generate_events
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 ################################################################################
 #
 # Copyright (c) 2011 The MadGraph5_aMC@NLO Development team and Contributors

--- a/generators/madgraph5/src/BREM_soCalledWabs_forHPS/SubProcesses/makefile
+++ b/generators/madgraph5/src/BREM_soCalledWabs_forHPS/SubProcesses/makefile
@@ -1,5 +1,5 @@
 include ../../Source/make_opts
-FFLAGS+= -w
+FFLAGS+= -w -std=legacy
 
 # Definitions
 

--- a/generators/madgraph5/src/BREM_soCalledWabs_forHPS/bin/generate_events
+++ b/generators/madgraph5/src/BREM_soCalledWabs_forHPS/bin/generate_events
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 ################################################################################
 #
 # Copyright (c) 2011 The MadGraph5_aMC@NLO Development team and Contributors

--- a/generators/madgraph5/src/HPS_RadiativeTridents/SubProcesses/makefile
+++ b/generators/madgraph5/src/HPS_RadiativeTridents/SubProcesses/makefile
@@ -1,5 +1,5 @@
 include ../../Source/make_opts
-FFLAGS+= -w
+FFLAGS+= -w -std=legacy
 
 # Definitions
 

--- a/generators/madgraph5/src/HPS_RadiativeTridents/bin/generate_events
+++ b/generators/madgraph5/src/HPS_RadiativeTridents/bin/generate_events
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 ################################################################################
 #
 # Copyright (c) 2011 The MadGraph5_aMC@NLO Development team and Contributors

--- a/generators/madgraph5/src/HPS_soCalledBH/SubProcesses/makefile
+++ b/generators/madgraph5/src/HPS_soCalledBH/SubProcesses/makefile
@@ -1,5 +1,5 @@
 include ../../Source/make_opts
-FFLAGS+= -w
+FFLAGS+= -w -std=legacy
 
 # Definitions
 

--- a/generators/madgraph5/src/HPS_soCalledBH/bin/generate_events
+++ b/generators/madgraph5/src/HPS_soCalledBH/bin/generate_events
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 ################################################################################
 #
 # Copyright (c) 2011 The MadGraph5_aMC@NLO Development team and Contributors

--- a/generators/madgraph5/src/RAD/SubProcesses/makefile
+++ b/generators/madgraph5/src/RAD/SubProcesses/makefile
@@ -1,5 +1,5 @@
 include ../../Source/make_opts
-FFLAGS+= -w
+FFLAGS+= -w -std=legacy 
 
 # Definitions
 

--- a/generators/madgraph5/src/RAD/bin/generate_events
+++ b/generators/madgraph5/src/RAD/bin/generate_events
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 ################################################################################
 #
 # Copyright (c) 2011 The MadGraph5_aMC@NLO Development team and Contributors

--- a/generators/madgraph5/src/simp/SubProcesses/makefile
+++ b/generators/madgraph5/src/simp/SubProcesses/makefile
@@ -1,5 +1,5 @@
 include ../../Source/make_opts
-FFLAGS+= -w
+FFLAGS+= -w -std=legacy
 
 # Load additional dependencies of the bias module, if present
 ifeq (,$(wildcard ../bias_dependencies))

--- a/generators/madgraph5/src/simp/bin/generate_events
+++ b/generators/madgraph5/src/simp/bin/generate_events
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 ################################################################################
 #
 # Copyright (c) 2011 The MadGraph5_aMC@NLO Development team and Contributors

--- a/generators/madgraph5/src/tritrig/SubProcesses/makefile
+++ b/generators/madgraph5/src/tritrig/SubProcesses/makefile
@@ -1,5 +1,5 @@
 include ../../Source/make_opts
-FFLAGS+= -w -std=legacy
+FFLAGS+= -w -std=legacy 
 
 # Definitions
 

--- a/generators/madgraph5/src/tritrig/SubProcesses/makefile
+++ b/generators/madgraph5/src/tritrig/SubProcesses/makefile
@@ -1,5 +1,5 @@
 include ../../Source/make_opts
-FFLAGS+= -w
+FFLAGS+= -w -std=legacy
 
 # Definitions
 

--- a/generators/madgraph5/src/tritrig/bin/generate_events
+++ b/generators/madgraph5/src/tritrig/bin/generate_events
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 ################################################################################
 #
 # Copyright (c) 2011 The MadGraph5_aMC@NLO Development team and Contributors


### PR DESCRIPTION
- Update the fortran flags in Madgraph to use `-std=legacy` so the compilation works with recent GCC releases
- Use `python2` instead of `python` in script execution for Python 3 compatibility (hps-mc builds with Python 3 only, now)