### PR TITLE
Update help

### DIFF
--- a/examples/tritrig/.hpsmc
+++ b/examples/tritrig/.hpsmc
@@ -5,19 +5,19 @@ enable_ptags = True
 enable_copy_output_files = False
 
 [MG5]
-madgraph_dir = /work/slac/hps-mc/generators/madgraph5/src
+madgraph_dir = /work/slac/git/hps-mc/generators/madgraph5/src
 
 [StdHepConverter]
-egs5_dir = /work/slac/hps-mc/generators/egs5
+egs5_dir = /work/slac/git/hps-mc/generators/egs5
 
 [SLIC]
-slic_dir = /work/slac/sim/slic/install-geant4-v10_06_p01
-hps_fieldmaps_dir = /work/slac/hps-fieldmaps
-detector_dir = /work/slac/hps-java/hps-java/detector-data/detectors
+slic_dir = /work/slac/git/slic/install
+hps_fieldmaps_dir = /work/slac/git/hps-fieldmaps
+detector_dir = /work/slac/git/hps-java/detector-data/detectors
 
 [JobManager]
-hps_java_bin_jar = /home/jermc/.m2/repository/org/hps/hps-distribution/4.5-SNAPSHOT/hps-distribution-4.5-SNAPSHOT-bin.jar
+hps_java_bin_jar = /home/jeremy/.m2/repository/org/hps/hps-distribution/4.5-SNAPSHOT/hps-distribution-4.5-SNAPSHOT-bin.jar
 java_args = -Xmx1g -XX:+UseSerialGC
 
 [FilterBunches]
-hps_java_bin_jar = /home/jermc/.m2/repository/org/hps/hps-distribution/4.5-SNAPSHOT/hps-distribution-4.5-SNAPSHOT-bin.jar
+hps_java_bin_jar = /home/jeremy/.m2/repository/org/hps/hps-distribution/4.5-SNAPSHOT/hps-distribution-4.5-SNAPSHOT-bin.jar

--- a/examples/tritrig/.hpsmc
+++ b/examples/tritrig/.hpsmc
@@ -5,19 +5,19 @@ enable_ptags = True
 enable_copy_output_files = False
 
 [MG5]
-madgraph_dir = /work/slac/git/hps-mc/generators/madgraph5/src
+madgraph_dir = /work/slac/hps-mc/generators/madgraph5/src
 
 [StdHepConverter]
-egs5_dir = /work/slac/git/hps-mc/generators/egs5
+egs5_dir = /work/slac/hps-mc/generators/egs5
 
 [SLIC]
-slic_dir = /work/slac/git/slic/install
-hps_fieldmaps_dir = /work/slac/git/hps-fieldmaps
-detector_dir = /work/slac/git/hps-java/detector-data/detectors
+slic_dir = /work/slac/sim/slic/install-geant4-v10_06_p01
+hps_fieldmaps_dir = /work/slac/hps-fieldmaps
+detector_dir = /work/slac/hps-java/hps-java/detector-data/detectors
 
 [JobManager]
-hps_java_bin_jar = /home/jeremy/.m2/repository/org/hps/hps-distribution/4.5-SNAPSHOT/hps-distribution-4.5-SNAPSHOT-bin.jar
+hps_java_bin_jar = /home/jermc/.m2/repository/org/hps/hps-distribution/4.5-SNAPSHOT/hps-distribution-4.5-SNAPSHOT-bin.jar
 java_args = -Xmx1g -XX:+UseSerialGC
 
 [FilterBunches]
-hps_java_bin_jar = /home/jeremy/.m2/repository/org/hps/hps-distribution/4.5-SNAPSHOT/hps-distribution-4.5-SNAPSHOT-bin.jar
+hps_java_bin_jar = /home/jermc/.m2/repository/org/hps/hps-distribution/4.5-SNAPSHOT/hps-distribution-4.5-SNAPSHOT-bin.jar

--- a/python/hpsmc/help.py
+++ b/python/hpsmc/help.py
@@ -1,5 +1,9 @@
 """Utility script for printing help about component classes."""
 
+from component import Component
+from job import Job
+
+# These are here so all available components appear in the globals dict.
 from tools import *
 from generators import *
 
@@ -45,11 +49,38 @@ def print_component(v):
 
 def print_components():
     """Print info for all Component classes."""
+    print("AVAILABLE COMPONENTS: ")
     for k in sorted(globals().keys()):
         v = globals()[k]
         if isinstance(v, Component.__class__):
             if v.__name__ not in _ignore:
-                print_component(v)
+                print('    {}'.format(v.__name__))
+
+def print_job_script(script_path):
+
+    job = Job()
+    job.script = script_path
+
+    # Dummy parameters so certain scripts don't crash when loaded.
+    job.input_files = {'signal': 'signal',
+                       'beam': 'beam'}
+    job.output_files = {'dummy.out': 'dummy.out'}
+    job.params['run_params'] = '4pt55'
+    job.params['nevents'] = 9999
+
+    job._load_script()
+
+    print('JOB SCRIPT: {}'.format(job.script))
+    print('')
+    print('    DESCRIPTION: {}'.format(job.description))
+    print('')
+    print('    COMPONENTS:')
+    for component in job.components:
+        print('        {}'.format(component.__class__.__name__))
+    print('')
+    print('    PTAGS:')
+    for ptag in job.ptags:
+        print('        {}'.format(ptag))
 
 if __name__ == '__main__':
     print_components()

--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -332,8 +332,7 @@ class Job(object):
 
         logger.debug('Loading job script: %s' % script_path)
 
-        globals = {'job': self}
-        exec(compile(open(script_path, "rb").read(), script_path, 'exec'), globals)
+        exec(compile(open(script_path, "rb").read(), script_path, 'exec'), {'job': self})
 
     def run(self):
         """
@@ -436,12 +435,12 @@ class Job(object):
 
     def __setup(self):
 
-         # Create run dir if it does not exist
+        # Create run dir if it does not exist
         if not os.path.exists(self.rundir):
             logger.info('Creating run dir: %s' % self.rundir)
             os.makedirs(self.rundir)
 
-         # Change to run dir
+        # Change to run dir
         logger.debug('Changing to run dir: %s' % self.rundir)
         os.chdir(self.rundir)
 
@@ -616,8 +615,8 @@ class Job(object):
 
 cmds = {
     'run': 'Run a job script',
-    'avail': 'Print available job names',
-    'components': 'Print detailed help for all components (or provide component name)'}
+    'script': 'Show list of available job scripts (provide script name for detailed info)',
+    'component': 'Show list of available components (provide component name for detailed info)'}
 
 def print_usage():
     print("Usage: job.py [command] [args]")
@@ -636,15 +635,20 @@ if __name__ == '__main__':
             job = Job(args)
             job.parse_args()
             job.run()
-        elif cmd == 'avail':
-            scriptdb = JobScriptDatabase()
-            print("Available job scripts: ")
-            for name in sorted(scriptdb.get_script_names()):
-                print('    %s: %s' % (name, scriptdb.get_script_path(name)))
-        elif cmd == 'components':
+        elif cmd == 'script':
             if len(sys.argv) > 2:
-                component_name = sys.argv[2]
+                script = sys.argv[2]
+                from hpsmc.help import print_job_script
+                print_job_script(script)
+            else:
+                scriptdb = JobScriptDatabase()
+                print("AVAILABLE JOB SCRIPTS: ")
+                for name in sorted(scriptdb.get_script_names()):
+                    print('    %s: %s' % (name, scriptdb.get_script_path(name)))
+        elif cmd == 'component':
+            if len(sys.argv) > 2:
                 from hpsmc.help import print_component
+                component_name = sys.argv[2]
                 print_component(component_name)
             else:
                 from hpsmc.help import print_components

--- a/python/jobs/lcio_count_job.py
+++ b/python/jobs/lcio_count_job.py
@@ -2,12 +2,12 @@ from hpsmc.tools import LCIOCount
 
 job.description = 'LCIO count'
 
-output_files = sorted(job.params.output_files.keys())
+output_files = sorted(job.output_files.keys())
 if len(output_files) < 1:
     raise Exception("Not enough output files were provided (at least 1 required).")
 
-nevents = job.params.nevents
+nevents = job.params['nevents']
 
 count = LCIOCount(minevents=nevents, inputs=output_files)
 
-job.components = [count]
+job.add([count])

--- a/python/jobs/wab_sample_job.py
+++ b/python/jobs/wab_sample_job.py
@@ -18,7 +18,7 @@ rot = BeamCoords()
 
 # Sample wabs using poisson distribution, calculating mu from provided LHE file
 sample = MergePoisson(input_filter='wab',
-                      lhe_file=iter(job.input_files.items()).next()[1],
+                      lhe_file=next(iter(job.input_files.values())),
                       nevents=500000)
 
 # Add components


### PR DESCRIPTION
Update the command line help tools to do the following...

Print a list of all available job scripts:
```
hps-mc-job script
```

Print detailed help for a job script by name:
```
hps-mc-job script tritrig
```

Print list of components:
```
hps-mc-job component
```

Print detailed help for a component by name:
```
hps-mc-job component SLIC
```

Also added some additional information to job script and component print outs.

Several out of date job scripts were corrected so they did not crash.