### PR TITLE
Fix LSF submission issue and other minor changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,15 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 
 project(hps-mc VERSION 2.0.0)
 
-# Find Python 3 executable
-find_package(PythonInterp)
-if(${PYTHON_VERSION_MAJOR} LESS 3)
-    message(FATAL_ERROR "Python 3 is required.")
-endif()
-set(PYTHON ${PYTHON_EXECUTABLE})
-message(STATUS "Python executable found at: ${PYTHON_EXECUTABLE}")
+# Find Python 3
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+message(STATUS "Python3 executable found at: ${Python3_EXECUTABLE}")
+set(PYTHON ${Python3_EXECUTABLE})
+
+# Find Python 2
+#find_package(Python2 COMPONENTS Interpreter REQUIRED)
+#message(STATUS "Python2 executable found at: ${Python2_EXECUTABLE}")
 
 # Check for Fortran compiler
 find_program(GFORTRAN gfortran)
@@ -50,8 +51,15 @@ foreach(SCRIPT_IN ${SCRIPTS_IN})
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 endforeach()
 
-# Recursively install all generator files.
-install(DIRECTORY generators DESTINATION share USE_SOURCE_PERMISSIONS)
+
+# Recursively install all generator files
+option(ENABLE_INSTALL_GENERATORS "Install physics generators (EGS5, Madgraph)" ON)
+if(ENABLE_INSTALL_GENERATORS)
+    message(STATUS "Physics generators will be installed automatically.")
+    install(DIRECTORY generators DESTINATION share USE_SOURCE_PERMISSIONS)
+else()
+    message(STATUS "Installation of physics generators is disabled.")
+endif()
 
 # Install python scripts
 install(DIRECTORY python DESTINATION lib)

--- a/config/jeremym_slac_centos7.cfg
+++ b/config/jeremym_slac_centos7.cfg
@@ -1,0 +1,13 @@
+[SLIC]
+slic_dir = /nfs/slac/g/hps/sw/slic/slic-deps-install-centos7-gcc8.3.1
+hps_fieldmaps_dir = /nfs/slac/g/hps/sw/hps-fieldmaps
+detector_dir = /nfs/slac/g/hps/sw/hps-java/master/detector-data/detectors
+
+[FilterBunches]
+hps_java_bin_jar =  /u/ey/jeremym/.m2/repository/org/hps/hps-distribution/4.5-SNAPSHOT/hps-distribution-4.5-SNAPSHOT-bin.jar
+
+[JobManager]
+hps_java_bin_jar =  /u/ey/jeremym/.m2/repository/org/hps/hps-distribution/4.5-SNAPSHOT/hps-distribution-4.5-SNAPSHOT-bin.jar
+
+[LCIOCount]
+lcio_bin_jar=/work/slac/sim/lcio/LCIO-02-07-05/target/lcio-2.7.4-SNAPSHOT-bin.jar

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,10 @@
 # Local JSON job store files
 */jobs.json
+
+# Example log files
+job.*.out
+job.*.err
+job.*.log
+job.out
+job.err
+job.log

--- a/examples/tritrig_gen/cleanup.sh
+++ b/examples/tritrig_gen/cleanup.sh
@@ -1,1 +1,1 @@
-rm -rf output scratch &> /dev/null
+rm -rf output scratch logs &> /dev/null

--- a/examples/tritrig_gen/submit_lsf.sh
+++ b/examples/tritrig_gen/submit_lsf.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+hps-mc-batch lsf -l $PWD/logs tritrig_gen jobs.json

--- a/python/hpsmc/batch.py
+++ b/python/hpsmc/batch.py
@@ -245,7 +245,7 @@ class LSF(Batch):
         out,err = proc.communicate()
         if err != None and len(err):
             logger.warning(err)
-        tokens = out.split(' ')
+        tokens = out.decode().split(" ")
         if tokens[0] != 'Job':
             raise Exception('Unexpected output from bsub command: %s' % out)
         batch_id = int(tokens[1].replace('<', '').replace('>', ''))


### PR DESCRIPTION
- Fix the issue with parsing output from LSF batch submission (reported by @cbravo135). 
- Bump the required CMake version to 3.12
- Update the cmake macro for finding Python3
- Add an option to disable automatic installation of generator tools (use `-DENABLE_INSTALL_GENERATORS=OFF` to disable installation as it is on by default)
- Add my working config for SLAC dev work and testing
- Update .gitignore of examples to ignore log files.
- Minor updates to the tritrig_gen example including the addition of a simple LSF submission script
