### PR TITLE
Slurm batch submission

### DIFF
--- a/examples/beam_gen/.hpsmc
+++ b/examples/beam_gen/.hpsmc
@@ -1,5 +1,6 @@
 [Job]
 dry_run = False 
 enable_file_chaining = True
-check_output_files = False
+check_output_files = True
 enable_copy_output_files = True
+delete_rundir = True

--- a/examples/beam_gen/job.json
+++ b/examples/beam_gen/job.json
@@ -1,5 +1,5 @@
 {
-    "run_number": 10666,
+    "run_number": 10031,
     "bunches": 250000,
     "nevents": 250000,
     "seed": 1001002,

--- a/examples/beam_gen/job.json.tmpl
+++ b/examples/beam_gen/job.json.tmpl
@@ -4,10 +4,9 @@
     "run_params": "{{ run_params }}",
     "target_z": {{ target_z }},
     "run_number": {{ run_number }},
-    "detector": "{{ detector }}",
+    "seed": {{ 61029001 + job_id }},
     "output_files": {
-        "beam.stdhep": "stdhep/beam_{{ job_id }}.stdhep",
-        "beam_rot_sampled.stdhep": "stdhep/beam_rot_sampled_{{ job_id }}.slcio"
+        "beam_rot_sampled.stdhep": "beam_{{run_params}}_20um120uA_{{ job_id }}.stdhep"
     },
-    "output_dir": "output"
+    "output_dir": "/sdf/group/hps/users/bravo/src/hps-mc/examples/beam_gen/outputBeam4pt55"
 }

--- a/examples/beam_gen/mkjobs.sh
+++ b/examples/beam_gen/mkjobs.sh
@@ -1,1 +1,1 @@
-hps-mc-job-template -j 1 -r 8 -a vars.json job.json.tmpl jobs.json
+hps-mc-job-template -j 1 -r 10000 -a vars.json job.json.tmpl jobs.json

--- a/examples/beam_gen/run.sh
+++ b/examples/beam_gen/run.sh
@@ -1,1 +1,3 @@
-hps-mc-job run -d $PWD/scratch beam_gen job.json
+#!/bin/bash
+source /sdf/group/hps/users/bravo/src/hps-mc/install/bin/hps-mc-env.sh
+hps-mc-job run -d $PWD/scratch -l $PWD/logs/job.log beam_gen job.json

--- a/examples/beam_gen/run_slurm.sh
+++ b/examples/beam_gen/run_slurm.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+hps-mc-batch slurm -o -q shared -r 3001:4000 -E /sdf/group/hps/users/bravo/src/hps-mc/install/bin/hps-mc-env.sh -W 5 -d /scratch/bravo -c /sdf/group/hps/users/bravo/src/hps-mc/examples/beam_gen/.hpsmc -l /scratch/bravo/logs beam_gen /sdf/group/hps/users/bravo/src/hps-mc/examples/beam_gen/jobs.json 

--- a/examples/beam_gen/run_slurm.sh
+++ b/examples/beam_gen/run_slurm.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-hps-mc-batch slurm -o -q shared -r 3001:4000 -E /sdf/group/hps/users/bravo/src/hps-mc/install/bin/hps-mc-env.sh -W 5 -d /scratch/bravo -c /sdf/group/hps/users/bravo/src/hps-mc/examples/beam_gen/.hpsmc -l /scratch/bravo/logs beam_gen /sdf/group/hps/users/bravo/src/hps-mc/examples/beam_gen/jobs.json 
+hps-mc-batch slurm -o -q shared -r 2001:3000 -E /sdf/group/hps/users/bravo/src/hps-mc/install/bin/hps-mc-env.sh -W 5 -d /scratch/bravo -c /sdf/group/hps/users/bravo/src/hps-mc/examples/beam_gen/.hpsmc -l /scratch/bravo/logs beam_gen /sdf/group/hps/users/bravo/src/hps-mc/examples/beam_gen/jobs.json 

--- a/examples/beam_gen/vars.json
+++ b/examples/beam_gen/vars.json
@@ -1,8 +1,7 @@
 {
-    "bunches": [25000],
-    "nevents": [25000],
+    "bunches": [250000],
+    "nevents": [250000],
     "run_params": ["4pt55"],
-    "detector": ["HPS-PhysicsRun2019-v2-4pt5"],
     "target_z": [-7.51],
     "run_number": [10666]
 }

--- a/python/hpsmc/batch.py
+++ b/python/hpsmc/batch.py
@@ -287,7 +287,7 @@ class Slurm(Batch):
         sh_file.write('source '+self.env+'\n')
         sh_file.write('mkdir -p %s/%i\n'%(self.run_dir, job_params['job_id']))
         sh_file.write('cd %s/%i\n'%(self.run_dir, job_params['job_id']))
-        sh_file.write(' '.join(Batch.build_cmd(self, name, job_params, set_job_dir=False)) + '\n')        
+        sh_file.write(' '.join(Batch.build_cmd(self, name, job_params, set_job_dir=True)) + '\n')        
         sh_file.close()
         cmd.append(sh_filename)
         

--- a/python/hpsmc/generators.py
+++ b/python/hpsmc/generators.py
@@ -83,7 +83,7 @@ class EGS5(EventGenerator):
         shutil.copy(src, dest)
 
     def required_parameters(self):
-        return ['run_params']
+        return ['seed', 'run_params']
 
     def optional_parameters(self):
         return ['bunches', 'target_thickness']


### PR DESCRIPTION
Added Slurm to batch.py so we can now submit jobs via Slurm. There are a few ways to accomplish this, since Slurm has job array submission built in, one can submit individual jobs via hps-mc or one can write a script to do all the jobs by first letting hps-mc generate the job command first.