### PR TITLE
File must exist before you try to chmod it

### DIFF
--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -564,8 +564,8 @@ class Job(object):
             if os.path.dirname(dest):
                 raise Exception("The input file destination '%s' is not valid." % dest)
             logger.info("Copying input file: %s -> %s" % (src, os.path.join(self.rundir, dest)))
-            os.chmod(dest, 0o666)
             shutil.copyfile(src, os.path.join(self.rundir, dest))
+            os.chmod(dest, 0o666)
 
     def __symlink_input_files(self):
         """


### PR DESCRIPTION
Hotfix for minor bug from recent PR. The current master will crash if the copied input file is not already in the run_dir.