### PR TITLE
changed default path to MG5 config file

### DIFF
--- a/generators/madgraph5/src/simp/Cards/me5_configuration.txt
+++ b/generators/madgraph5/src/simp/Cards/me5_configuration.txt
@@ -221,7 +221,7 @@ automatic_html_opening = False
 # amcfast = amcfast-config
 
 
-mg5_path = /gpfs/slac/atlas/fs1/d/ssevova/MG5_aMC_v2_5_3 
+mg5_path = /Users/zym/MG5_aMC_v2_4_2 
 
 # MG5 MAIN DIRECTORY
-mg5_path = /gpfs/slac/atlas/fs1/d/ssevova/MG5_aMC_v2_5_3
+mg5_path = /Users/zym/MG5_aMC_v2_4_2


### PR DESCRIPTION
Path in me5_configuration.txt exists on some systems used by HPS. Permission error crashes software. Changed path to non-existent path, so default config file path is used. 