### PR TITLE
Increase shutil copy buffer size

### DIFF
--- a/python/hpsmc/__init__.py
+++ b/python/hpsmc/__init__.py
@@ -1,4 +1,10 @@
+import shutil
+
 from .util import config_logging
 
 # Enable default logging config
 config_logging()
+
+# To play nice with Lustre, but only effective as of python 3.8
+shutil.COPY_BUFSIZE = 1024*1024
+


### PR DESCRIPTION
On Linux, the default is 16 kB in older versions, increases to 64 kB probably at python 3.8, but still too small to play nice with Lustre filesystem at JLab.  Here we increase it to 1 MB.  Note, this is only effective as of python 3.8.  If we need to use an older python version, then to increase shutil's buffer size requires using shutil.copyfileobj everywhere with an explicit buffer size argument.