### PR TITLE
update for hps-mc package installation with python3.9.5 at JLab

### DIFF
--- a/build_jlab.sh
+++ b/build_jlab.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+(
+    rm -rf build && mkdir -p build && cd build
+    cmake .. \
+	-DCMAKE_INSTALL_PREFIX=$(realpath ../install) \
+        -DPython3_EXECUTABLE=/apps/python/3.9.5/bin/python3 \
+        -DCMAKE_BUILD_TYPE=RelWithDbInfo \
+        -DCMAKE_CXX_COMPILER=$(which g++) -DCMAKE_C_COMPILER=$(which gcc) \
+        -DHPSMC_ENABLE_EGS5=ON \
+        -DHPSMC_ENABLE_MADGRAPH=ON \
+        -DHPSMC_ENABLE_STDHEP=ON \
+        -DHPSMC_ENABLE_FIELDMAPS=ON \
+        -DHPSMC_ENABLE_LCIO=ON \
+        -DHPSMC_ENABLE_HPSJAVA=OFF \
+        -DHPSMC_ENABLE_CONDITIONS=OFF
+    make install
+)

--- a/python/hpsmc/batch.py
+++ b/python/hpsmc/batch.py
@@ -8,6 +8,10 @@ import sys
 import logging
 import signal
 import multiprocessing
+
+# The site-package psutil for /apps/python/3.9.5 is customizedly installed at /group/hps/hps_soft/python3.9.5/site-packages at JLab
+if os.path.isdir("/group/hps/hps_soft/python3.9.5/site-packages"):
+    sys.path.append("/group/hps/hps_soft/python3.9.5/site-packages")
 import psutil
 
 import xml.etree.ElementTree as ET

--- a/python/hpsmc/job_template.py
+++ b/python/hpsmc/job_template.py
@@ -9,6 +9,9 @@ import argparse
 import math
 import uuid as _uuid
 
+# The package jinja2 is installed at /apps/python/3.4.3/lib/python3.4/site-packages at JLab
+if os.path.isdir("/apps/python/3.4.3/lib/python3.4/site-packages"):
+    sys.path.append("/apps/python/3.4.3/lib/python3.4/site-packages")
 from jinja2 import Template, Environment, FileSystemLoader
 
 def basename(path):

--- a/scripts/jlab-env.csh.in
+++ b/scripts/jlab-env.csh.in
@@ -1,1 +1,2 @@
 module load gcc/@CMAKE_C_COMPILER_VERSION@
+module load python/3.9.5


### PR DESCRIPTION
To set buffer size for shutil, we use /apps/python/3.9.5 to reinstall hps-mc at JLab. However, some site-packages are only installed in /apps/python/3.4.3. To solve the issue, sys.path is appended. The package jinja2 from /apps/python/3.4.3 is applied. The package psutil is installed at /group/hps/hps_soft/python3.9.5/site-packages, and then applied. 