### PR TITLE
fix an issue for setup of input file list of components

### DIFF
--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -576,7 +576,8 @@ class Job(object):
             elif i > -1:
                 logger.debug("Setting inputs on '%s' to: %s"
                             % (c.name, str(self.components[i - 1].output_files())))
-                c.inputs = self.components[i - 1].output_files()
+                if len(c.inputs) == 0:
+                    c.inputs = self.components[i - 1].output_files()
 
     def __set_parameters(self):
         """


### PR DESCRIPTION
In a chain, input file list of current step  is mandatorily set as output from last step. However, we need to set specified inputs for some components. The PR fixes this issue.