### PR TITLE
Load modules for JLab environment

### DIFF
--- a/scripts/jlab-env.csh.in
+++ b/scripts/jlab-env.csh.in
@@ -1,1 +1,3 @@
+module load cmake/@CMAKE_VERSION@
 module load gcc/@CMAKE_C_COMPILER_VERSION@
+module load python/@Python3_VERSION@


### PR DESCRIPTION
Resolves #294

Load the modules necessary for running hps-mc at JLab using Swif.