### PR TITLE
update jlab.cfg

### DIFF
--- a/config/jlab.cfg
+++ b/config/jlab.cfg
@@ -1,27 +1,36 @@
-[StdHepConverter]
-egs5_dir = /group/hps/sw/hps-mc/dev/src/generators/egs5
-
 [MG4]
-madgraph_dir = /group/hps/sw/hps-mc/dev/src/generators/madgraph4/src
+madgraph_dir = /u/group/hps/sw/hps-mc/generators/madgraph4/src
 
 [MG5]
-madgraph_dir = /group/hps/sw/hps-mc/dev/src/generators/madgraph5/src
+madgraph_dir = /u/group/hps/sw/hps-mc/generators/madgraph5/src
+
+[EGS5]
+egs5_dir = /u/group/hps/sw/hps-mc/generators/egs5
+
+[StdHepConverter]
+egs5_dir = /u/group/hps/sw/hps-mc/generators/egs5
 
 [SLIC]
-slic_dir = /group/hps/hps_soft/sim/slic/slic-install
-hps_fieldmaps_dir = /group/hps/hps_soft/fieldmap
-detector_dir = /group/hps/hps_soft/detector-data/detectors 
+slic_dir = /u/group/hps/hps_soft/sim/slic-6.1.1/install 
+hps_fieldmaps_dir = /group/hps/hps_soft/fieldmap 
+detector_dir = /group/hps/hps_soft/detector-data/detectors  
 
 [JobManager]
-hps_java_bin_jar = /group/hps/hps_soft/hps-java-master/distribution/target/hps-distribution-4.5-SNAPSHOT-bin.jar
+hps_java_bin_jar = /u/group/hps/hps_soft/hps-java/hps-distribution-5.1-SNAPSHOT-bin.jar 
 java_args = -Xmx1g -XX:+UseSerialGC
 
 [FilterBunches]
-hps_java_bin_jar = /group/hps/hps_soft/hps-java-master/distribution/target/hps-distribution-4.5-SNAPSHOT-bin.jar
+hps_java_bin_jar = /u/group/hps/hps_soft/hps-java/hps-distribution-5.1-SNAPSHOT-bin.jar 
+
+[ExtractEventsWithHitAtHodoEcal]
+hps_java_bin_jar = /u/group/hps/hps_soft/hps-java/hps-distribution-5.1-SNAPSHOT-bin.jar
 
 [HPSTR]
-hpstr_install_dir = /group/hps/sw/hpstr/dev/install-centos7-gcc4.8.5
-hpstr_base = /group/hps/sw/hpstr/dev/src
+hpstr_install_dir = /u/group/hps/hps_soft/hpstr/install 
+hpstr_base = /u/group/hps/hps_soft/hpstr/src/hpstr
 
 [LCIOCount]
-lcio_bin_jar = /group/hps/hps_soft/sim/lcio/lcio/target/lcio-2.7.4-SNAPSHOT-bin.jar
+lcio_bin_jar = /group/hps/hps_soft/sim/lcio/lcio/target/lcio-2.7.4-SNAPSHOT-bin.jar 
+
+[LCIOMerge]
+lcio_bin_jar = /group/hps/hps_soft/sim/lcio/lcio/target/lcio-2.7.4-SNAPSHOT-bin.jar 


### PR DESCRIPTION
Some softwares, such as hps-mc, slic, and hpstr are re-installed at public place /u/group/hps with hps account. Based on these software updates, jlab.cfg in hps-mc/config is updated for HPS users to apply hps-mc at JLab.