### PR TITLE
Pycodestyle action

### DIFF
--- a/.github/workflows/pycodestyle.yml
+++ b/.github/workflows/pycodestyle.yml
@@ -17,4 +17,4 @@ jobs:
         pip install pycodestyle
     - name: Run pycodestyle
       run: |
-        pycodestyle --ignore=E266,E501 --max-line-length=160 python/
+        pycodestyle --ignore=E266,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --max-line-length=160 python/

--- a/.github/workflows/pycodestyle.yml
+++ b/.github/workflows/pycodestyle.yml
@@ -1,0 +1,20 @@
+name: pycodestyle
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pycodestyle
+    - name: Run pycodestyle
+      run: |
+        pycodestyle --ignore=E266,E501 --max-line-length=160 python/

--- a/README.md
+++ b/README.md
@@ -116,6 +116,45 @@ After one has generated a jobs.json file, the jobs it defines can be ran locally
 
 It is recommended to slowly build up jobs and tests them locally first before submitting a whole set to a batch system to run. This can be with commands nearly identical to the commands used to submit the jobs to a batch system (local or pool). The system is pretty abstracted so you might even find a new clever way to leverage the features of hps-mc to speed up the process of defining job sets, or even just getting the jobs ran.
 
+
+### Code Formatting
+There is a github action ensuring proper formatting of python code in `hps-mc`. This action will fail if the pushed code does not follow the **PEP 8 style conventions**.
+
+To prevent this action from failing, you can check if your code is formatted correctly locally before pushing. This can be done using [pycodestyle](https://pycodestyle.pycqa.org/en/latest/intro.html#configuration), by navigating to the top directory of hps-mc and running
+```bash
+pycodestyle --ignore=E266,E501 --max-line-length=160 python/
+```
+which will display all formatting errors in `python/`. Before running this, make sure pycodestyle is installed on your machine. If you need to install it, you can do this by running
+```bash
+pip install --user pycodestyle
+```
+
+You can automate the style check by creating a git pre-commit hook. This will automatically check the formatting of changed and added python files upon running `git commit`. To add the pre-commit hook, navigate to the `.git/hooks/` directory in `hps-mc`, create a pre-commit hook, and make it executable. If you already have pre-commit hooks, you can skip this step.
+```bash
+cd .git/hooks
+touch pre-commit
+chmod +x pre-commit
+```
+Then, add the following lines to `pre-commit`
+```bash
+#!/bin/sh
+FILES=$(git diff --cached --name-only --diff-filter=ACMR)
+pycodestyle --ignore=E266,E501 --max-line-length=160 ${FILES}
+```
+ 
+To fix the formatting errors, you can either do this manually by navigating to the displayed files and making the necessary changes, or you can use [autopep8](https://pypi.org/project/autopep8/#installation) as follows. First, install autopep8:
+```bash
+pip install --user --upgrade autopep8
+```
+Then run
+```bash
+autopep8 --aggressive --aggressive --ignore=E265,E501 --in-place --max-line-length=160 --recursive python/
+```
+from the top of the `hps-mc` directory. Alternatively, run `format_python_code.sh`.
+This will automatically fix (most) of the formatting issues. 
+
+To preserve the Doxygen-style comments, it is necessary to disable the automatic formatting of comment blocks which means that you might need to fix those by hand.
+
 ### Help
 
 You can post any questions or report problems on the [HPS Slack](https://heavyphotonsearch.slack.com/) in the [montecarlo](https://heavyphotonsearch.slack.com/messages/C47LLBP5F) channel.

--- a/README.md
+++ b/README.md
@@ -122,14 +122,14 @@ There is a github action ensuring proper formatting of python code in `hps-mc`. 
 
 To prevent this action from failing, you can check if your code is formatted correctly locally before pushing. This can be done using [pycodestyle](https://pycodestyle.pycqa.org/en/latest/intro.html#configuration), by navigating to the top directory of hps-mc and running
 ```bash
-pycodestyle --ignore=E266,E501 --max-line-length=160 python/
+pycodestyle --ignore=E266,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --max-line-length=160 python/
 ```
 which will display all formatting errors in `python/`. Before running this, make sure pycodestyle is installed on your machine. If you need to install it, you can do this by running
 ```bash
 pip install --user pycodestyle
 ```
 
-You can automate the style check by creating a git pre-commit hook. This will automatically check the formatting of changed and added python files upon running `git commit`. To add the pre-commit hook, navigate to the `.git/hooks/` directory in `hps-mc`, create a pre-commit hook, and make it executable. If you already have pre-commit hooks, you can skip this step.
+You can automate the style check by creating a git pre-commit hook. This will automatically check all python files upon running `git commit`. To add the pre-commit hook, navigate to the `.git/hooks/` directory in `hps-mc`, create a pre-commit hook, and make it executable. If you already have pre-commit hooks, you can skip this step.
 ```bash
 cd .git/hooks
 touch pre-commit
@@ -138,8 +138,7 @@ chmod +x pre-commit
 Then, add the following lines to `pre-commit`
 ```bash
 #!/bin/sh
-FILES=$(git diff --cached --name-only --diff-filter=ACMR)
-pycodestyle --ignore=E266,E501 --max-line-length=160 ${FILES}
+pycodestyle --ignore=E266,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --max-line-length=160 python/
 ```
  
 To fix the formatting errors, you can either do this manually by navigating to the displayed files and making the necessary changes, or you can use [autopep8](https://pypi.org/project/autopep8/#installation) as follows. First, install autopep8:
@@ -148,7 +147,7 @@ pip install --user --upgrade autopep8
 ```
 Then run
 ```bash
-autopep8 --aggressive --aggressive --ignore=E265,E501 --in-place --max-line-length=160 --recursive python/
+autopep8 --aggressive --aggressive --ignore=E265,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --in-place --max-line-length=160 --recursive python/
 ```
 from the top of the `hps-mc` directory. Alternatively, run `format_python_code.sh`.
 This will automatically fix (most) of the formatting issues. 

--- a/format_python_code.sh
+++ b/format_python_code.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-autopep8 --aggressive --aggressive --ignore=E265,E501 --in-place --max-line-length=160 --recursive python/
+autopep8 --aggressive --aggressive --ignore=E265,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --in-place --max-line-length=160 --recursive python/

--- a/format_python_code.sh
+++ b/format_python_code.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+autopep8 --aggressive --aggressive --ignore=E265,E501 --in-place --max-line-length=160 --recursive python/

--- a/python/hpsmc/__init__.py
+++ b/python/hpsmc/__init__.py
@@ -6,5 +6,4 @@ from .util import config_logging
 config_logging()
 
 # To play nice with Lustre, but only effective as of python 3.8
-shutil.COPY_BUFSIZE = 1024*1024
-
+shutil.COPY_BUFSIZE = 1024 * 1024

--- a/python/hpsmc/component.py
+++ b/python/hpsmc/component.py
@@ -1,5 +1,5 @@
-"""! 
-@package component 
+"""!
+@package component
 Defines the base interface that component classes should extend.
 """
 
@@ -15,7 +15,7 @@ logger = logging.getLogger("hpsmc.component")
 class Component(object):
     """!
     Base class for components in a job.
-    
+
     Optional parameters are: **nevents**, **seed**
     """
 
@@ -94,7 +94,7 @@ class Component(object):
     def cmd_exists(self):
         """! Check if the component's assigned command exists."""
         return subprocess.call("type " + self.command, shell=True,
-            stdout = subprocess.PIPE, stderr=subprocess.PIPE) == 0
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
 
     def cmd_args(self):
         """! Return the command arguments of this component."""
@@ -116,7 +116,7 @@ class Component(object):
 
     def config(self, parser):
         """! Automatic configuartion
-        
+
         Automatically load attributes from config by reading in values from
         the section with the same name as the class in the config file and
         assigning them to class attributes with the same name.
@@ -126,9 +126,9 @@ class Component(object):
             for name, value in parser.items(section_name):
                 setattr(self, name, convert_config_value(value))
                 logger.debug("%s:%s:%s=%s" % (self.name,
-                                             name,
-                                             getattr(self, name).__class__.__name__,
-                                             getattr(self, name)))
+                                              name,
+                                              getattr(self, name).__class__.__name__,
+                                              getattr(self, name)))
 
     def set_parameters(self, params):
         """! Set class attributes for the component based on JSON parameters.
@@ -156,7 +156,7 @@ class Component(object):
                 if p not in self.ignore_job_params:
                     setattr(self, p, params[p])
                     logger.debug("%s:%s=%s [optional]"
-                                % (self.name, p, params[p]))
+                                 % (self.name, p, params[p]))
                 else:
                     logger.debug("Ignored job param '%s'" % p)
 
@@ -213,12 +213,12 @@ class Component(object):
         """
         outputs = []
         for infile in self.input_files():
-            f,ext = os.path.splitext(infile)
+            f, ext = os.path.splitext(infile)
             if self.append_tok is not None:
                 f += '_%s' % self.append_tok
             if self.output_ext is not None:
                 ext = self.output_ext
-            outputs.append('%s%s' % (f,ext))
+            outputs.append('%s%s' % (f, ext))
         return outputs
 
     def config_from_environ(self):
@@ -232,6 +232,7 @@ class Component(object):
             else:
                 raise Exception("Missing config in environ for '%s'" % c)
 
+
 class DummyComponent(Component):
     """! A dummy component that just prints some information instead of executing a program."""
 
@@ -240,4 +241,3 @@ class DummyComponent(Component):
 
     def execute(self, log_out, log_err):
         pass
-

--- a/python/hpsmc/config_writer.py
+++ b/python/hpsmc/config_writer.py
@@ -8,6 +8,7 @@ from generators import *
 from job import Job
 from help import _ignore
 
+
 def write_config(filename, component_names, include_defaults, fail_on_missing):
     """! Write a config file from environment variables.
     @param filename  name of config file
@@ -23,9 +24,9 @@ def write_config(filename, component_names, include_defaults, fail_on_missing):
         if isinstance(v, Component.__class__):
             if v.__name__ not in _ignore:
                 if len(component_names) and v.__name__ not in component_names:
-                    #print('Skipping ' + v.__name__)
+                    # print('Skipping ' + v.__name__)
                     continue
-                #print('Config env for ' + v.__name__)
+                # print('Config env for ' + v.__name__)
                 obj = eval(v.__name__)()
                 section = '[%s]\n' % v.__name__
                 lines += section
@@ -43,6 +44,7 @@ def write_config(filename, component_names, include_defaults, fail_on_missing):
         f.writelines(lines)
     print('Wrote config: %s' % filename)
 
+
 def write_config_for_job(job_script, filename, include_defaults, fail_on_missing):
     """! Write a config file for a specific job script.
     @param job_script  job script
@@ -57,6 +59,7 @@ def write_config_for_job(job_script, filename, include_defaults, fail_on_missing
     component_names = [c.__class__.__name__ for c in j.components]
     write_config('job.cfg', component_names, include_defaults, fail_on_missing)
 
+
 def _get_job_defaults():
     """! Get default job class settings."""
 
@@ -68,6 +71,7 @@ def _get_job_defaults():
         lines += '%s = %s\n' % (cj, v)
     lines += '\n'
     return lines
+
 
 if __name__ == '__main__':
 

--- a/python/hpsmc/func.py
+++ b/python/hpsmc/func.py
@@ -5,7 +5,8 @@ import logging
 
 logger = logging.getLogger("hpsmc.func")
 
-def lint(run_params, density = 6.306e-14):
+
+def lint(run_params, density=6.306e-14):
     """!
     Calculate integrated luminosity.
     @param run_params  run parameter
@@ -14,7 +15,8 @@ def lint(run_params, density = 6.306e-14):
     """
     w = run_params.get("target_z")
     ne = run_params.get("num_electrons")
-    return density*w*ne
+    return density * w * ne
+
 
 def csection(filename):
     """!
@@ -22,7 +24,7 @@ def csection(filename):
     WARNING: This function does not work!
 
     \todo remove or replace by more useful function
-    @param filename  name of input file 
+    @param filename  name of input file
     """
     logger.info("Using gzip to open '%s'" % filename)
 
@@ -31,13 +33,14 @@ def csection(filename):
 
     for line in lines:
         if "Integrated weight" in line:
-            xs = float(line[line.rfind(":")+1:].strip())
+            xs = float(line[line.rfind(":") + 1:].strip())
             break
 
     if "xs" not in locals():
         raise Exception("Could not find 'Integrated weight' in LHE input file.")
 
     return xs
+
 
 def mu(filename, run_params):
     """!
@@ -50,7 +53,8 @@ def mu(filename, run_params):
     """
     return lint(run_params) * csection(filename)
 
-def nevents(filename, confirm = False):
+
+def nevents(filename, confirm=False):
     """!
     Read number of events in file from LHE header and optionally confirm by counting <event> blocks.
     @param filename  name of input LHE file
@@ -76,6 +80,7 @@ def nevents(filename, confirm = False):
 
     return nevents
 
+
 def nbunches(filename, run_params):
     """!
     Get the approximate number of beam bunches represented by an LHE file from its event count.
@@ -84,12 +89,13 @@ def nbunches(filename, run_params):
     """
     n = nevents(filename)
     m = mu(filename, run_params)
-    return int(n/m)
+    return int(n / m)
+
 
 # TODO: wab LHE file fixup
 """
 echo "Transmuting A's to photons..."
 gunzip -f wab.lhe.gz
-sed -i 's/\([:blank:]*\)622 /\1 22 /' wab.lhe
+sed -i 's/\\([:blank:]*\\)622 /\1 22 /' wab.lhe
 gzip wab.lhe
 """

--- a/python/hpsmc/generators.py
+++ b/python/hpsmc/generators.py
@@ -12,8 +12,10 @@ from run_params import RunParameters
 
 logger = logging.getLogger("hpsmc.generators")
 
+
 class EventGenerator(Component):
     """! Event generator base class."""
+
     def __init__(self, name, command=None, **kwargs):
         Component.__init__(self, name, command=command, description='', **kwargs)
 
@@ -25,11 +27,12 @@ class EventGenerator(Component):
             raise Exception("HPSMC_DIR is not set!")
         return "{}/share/generators".format(os.getenv("HPSMC_DIR", None))
 
+
 class EGS5(EventGenerator):
     """!
     Run the EGS5 event generator to produce a StdHep file.
-    
-    Required parameters are **seed**, **run_parameters** \n 
+
+    Required parameters are **seed**, **run_parameters** \n
     Optional parameters are: **bunches**, **target_thickness**
     """
 
@@ -68,7 +71,7 @@ class EGS5(EventGenerator):
 
         if os.path.exists("pgs5job.pegs5inp"):
             os.unlink("pgs5job.pegs5inp")
-        os.symlink(self.egs5_config_dir + "/src/esa.inp",  "pgs5job.pegs5inp")
+        os.symlink(self.egs5_config_dir + "/src/esa.inp", "pgs5job.pegs5inp")
 
         logger.debug("Reading run parameters: {}".format(self.run_params))
         ## run parameters
@@ -128,8 +131,9 @@ class EGS5(EventGenerator):
         """
         return ['bunches', 'target_thickness']
 
-    #def required_config(self):
+    # def required_config(self):
     #    return ['egs5_dir']
+
 
 class StdHepConverter(EGS5):
     """! Convert LHE files to StdHep using EGS5."""
@@ -159,7 +163,7 @@ class StdHepConverter(EGS5):
         @return egs5 error code
         """
         input_file = self.inputs[0]
-        base,ext = os.path.splitext(input_file)
+        base, ext = os.path.splitext(input_file)
         if ext == ".lhe":
             os.symlink(input_file, "egs5job.inp")
         elif ext == ".gz":
@@ -174,13 +178,15 @@ class StdHepConverter(EGS5):
         """! Converts *.lhe.gz and *.lhe to *.stdhep files."""
         return [self.input_files()[0].replace(".lhe.gz", ".stdhep").replace(".lhe", ".stdhep")]
 
+
 class MG(EventGenerator):
     """!
     Abstract class for MadGraph generators.
 
     Required parameters are: **nevents**, **run_params** \n
-    Optional parameters are: **seed**, **param_card**, **apmass**, **map**, **mpid**, **mrhod** 
+    Optional parameters are: **seed**, **param_card**, **apmass**, **map**, **mpid**, **mrhod**
     """
+
     def __init__(self, name, **kwargs):
 
         ## Install dir or user config will be used for this.
@@ -241,7 +247,7 @@ class MG(EventGenerator):
         """
         return ['seed', 'param_card', 'apmass', 'map', 'mpid', 'mrhod']
 
-    #def required_config(self):
+    # def required_config(self):
     #    return ['madgraph_dir']
 
     def make_run_card(self, run_card):
@@ -310,17 +316,18 @@ class MG(EventGenerator):
         if self.name == 'ap' and self.apmass is None:
             raise Exception("Missing apmass param for AP generation.")
 
+
 class MG4(MG):
     """! Run the MadGraph 4 event generator."""
 
     ## \todo Put this information into a method in the MG superclass.
-    dir_map = {"BH"      : "BH/MG_mini_BH/apBH",
-               "RAD"     : "RAD/MG_mini_Rad/apRad",
-               "TM"      : "TM/MG_mini/ap",
-               "ap"      : "ap/MG_mini/ap",
-               "trigg"   : "trigg/MG_mini_Trigg/apTri",
-               "tritrig" : "tritrig/MG_mini_Tri_W/apTri",
-               "wab"     : "wab/MG_mini_WAB/AP_6W_XSec2_HallB" }
+    dir_map = {"BH": "BH/MG_mini_BH/apBH",
+               "RAD": "RAD/MG_mini_Rad/apRad",
+               "TM": "TM/MG_mini/ap",
+               "ap": "ap/MG_mini/ap",
+               "trigg": "trigg/MG_mini_Trigg/apTri",
+               "tritrig": "tritrig/MG_mini_Tri_W/apTri",
+               "wab": "wab/MG_mini_WAB/AP_6W_XSec2_HallB"}
 
     def __init__(self, name='ap', **kwargs):
 
@@ -348,7 +355,7 @@ class MG4(MG):
             os.makedirs(self.event_dir)
 
         self.command = os.path.join(os.getcwd(), proc_dirs[1], proc_dirs[2], "bin", "generate_events")
-        logger.debug("Command set to '%s'"  % self.command)
+        logger.debug("Command set to '%s'" % self.command)
 
         run_card_src = os.path.join(self.madgraph_dir, proc_dirs[0], self.run_card)
         run_card_dest = os.path.join(self.rundir, proc_dirs[1], proc_dirs[2], "Cards", "run_card.dat")
@@ -379,14 +386,15 @@ class MG4(MG):
         os.chdir(self.rundir)
         return returncode
 
+
 class MG5(MG):
     """! Run the MadGraph 5 event generator."""
 
     ## \todo: Put this information into a method in the MG superclass.
-    dir_map = {"BH"      : "BH",
-               "RAD"     : "RAD",
-               "tritrig" : "tritrig",
-               "simp"    : "simp"}
+    dir_map = {"BH": "BH",
+               "RAD": "RAD",
+               "tritrig": "tritrig",
+               "simp": "simp"}
 
     def __init__(self, name='tritrig', **kwargs):
 

--- a/python/hpsmc/help.py
+++ b/python/hpsmc/help.py
@@ -10,6 +10,7 @@ from generators import *
 # These are all interfaces and not runnable components, which should be ignored.
 _ignore = ('Component', 'EventGenerator', 'StdHepTool', 'JavaTool', 'MG')
 
+
 def print_component(v):
     """! Accepts Component class and prints info about it."""
     try:
@@ -36,16 +37,17 @@ def print_component(v):
         print('')
         try:
             print('    APPEND TOKEN:\n        %s' % obj.append_tok)
-        except:
+        except BaseException:
             pass
         print('')
         try:
             print('    OUTPUT EXTENSION:\n        %s' % obj.output_ext)
-        except:
+        except BaseException:
             pass
         print('')
     except Exception as e:
         print(e)
+
 
 def print_components():
     """! Print info for all Component classes."""
@@ -55,6 +57,7 @@ def print_components():
         if isinstance(v, Component.__class__):
             if v.__name__ not in _ignore:
                 print('    {}'.format(v.__name__))
+
 
 def print_job_script(script_path):
 
@@ -81,6 +84,7 @@ def print_job_script(script_path):
     print('    PTAGS:')
     for ptag in job.ptags:
         print('        {}'.format(ptag))
+
 
 if __name__ == '__main__':
     print_components()

--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -24,6 +24,8 @@ logger = logging.getLogger('hpsmc.job')
 logger.setLevel(logging.INFO)
 
 ## Unused, \todo remove?
+
+
 def check(j):
     jsonfile = j.application.args[1]
     with open(jsonfile) as datafile:
@@ -33,7 +35,7 @@ def check(j):
         output_dir = data["output_dir"]
     if "output_files" in data:
         outputfiles = data["output_files"]
-        for k,v in outputfiles.items():
+        for k, v in outputfiles.items():
             fpath = v
             if not os.path.isabs(v):
                 fpath = output_dir + os.path.sep + v
@@ -49,21 +51,22 @@ def load_json_data(filename):
     rawdata = open(filename, 'r').read()
     return json.loads(rawdata)
 
+
 class JobConfig(object):
     """! Wrapper for accessing config information from parser."""
 
-    #, include_default_locations=True
+    # , include_default_locations=True
     def __init__(self, config_files=[], include_default_locations=True):
         ## list of config files
         self.config_files = []
         if include_default_locations:
             self.config_files.extend([os.path.join(expanduser("~"), ".hpsmc"),
-                                          os.path.abspath(".hpsmc")])
+                                      os.path.abspath(".hpsmc")])
 
         if len(config_files):
             self.config_files.extend(config_files)
 
-        #if not len(self.config_files):
+        # if not len(self.config_files):
         #    raise Exception('No config file locations provided.')
 
         self._load()
@@ -74,20 +77,20 @@ class JobConfig(object):
         # Read in config files and crash if none are found from list
         ## configuration parser
         self.parser = configparser.ConfigParser()
-        #logger.debug("Checking for config files: %s" % str(self.config_files))
-        #parsed =
+        # logger.debug("Checking for config files: %s" % str(self.config_files))
+        # parsed =
         self.parser.read(self.config_files)
-        #if not len(parsed):
+        # if not len(parsed):
         #    raise Exception('No config files found in locations: %s' % str(self.config_files))
 
         # Print detailed config info to the log
-        #if len(parsed):
+        # if len(parsed):
 
     def __str__(self):
         parser_lines = ['JobConfig:']
         for section in self.parser.sections():
             parser_lines.append("[" + section + "]")
-            for i,v in self.parser.items(section):
+            for i, v in self.parser.items(section):
                 parser_lines.append("%s=%s" % (i, v))
             parser_lines.append('')
         return '\n'.join(parser_lines)
@@ -107,7 +110,7 @@ class JobConfig(object):
                 if req not in self.parser.items(section):
                     raise Exception("Missing required config '%s'" % req)
             # Push each config item into the object by setting attribute.
-            for name,value in self.parser.items(section):
+            for name, value in self.parser.items(section):
                 if len(allowed_names) and name not in allowed_names:
                     raise Exception("Config name '%s' is not allowed for '%s'" % (name, section))
                 setattr(obj, name, convert_config_value(value))
@@ -120,6 +123,7 @@ class JobConfig(object):
         else:
             logger.warning('Config section not found: %s' % section)
 
+
 class JobStore:
     """!
     Simple JSON based store of job data.
@@ -128,7 +132,7 @@ class JobStore:
     def __init__(self, path=None):
         self.path = path
         if path:
-            #logger.info("Initializing job store from: {}".format(self.path))
+            # logger.info("Initializing job store from: {}".format(self.path))
             self.load(path)
 
     def load(self, json_store):
@@ -141,7 +145,7 @@ class JobStore:
         self.data = {}
         for j in json_data:
             self.data[j['job_id']] = j
-        #logger.info("Loaded %d jobs from job store: %s" % (len(self.data), json_store))
+        # logger.info("Loaded %d jobs from job store: %s" % (len(self.data), json_store))
 
     def get_job(self, job_id):
         """! Get a job by its job ID.
@@ -161,9 +165,11 @@ class JobStore:
         """! Return true if the job ID exists in the store."""
         return job_id in list(self.data.keys())
 
+
 class JobScriptDatabase:
     """! Database of job scripts.
     """
+
     def __init__(self):
         if 'HPSMC_DIR' not in os.environ:
             raise Exception('HPSMC_DIR is not set in the environ.')
@@ -194,10 +200,11 @@ class JobScriptDatabase:
         @return True if job name is key in job dict"""
         return name in self.scripts
 
+
 class Job(object):
     """!
     Primary class to run HPS jobs from a Python script.
-    
+
     Jobs are run by executing a series of components
     which are configured using a config file with parameters
     provided by a JSON job file.
@@ -278,7 +285,7 @@ class Job(object):
 
         This method can be used in job scripts to define default values.
         """
-        for k,v in params.items():
+        for k, v in params.items():
             if k in self.params:
                 logger.debug("Setting new value '%s' for parameter '%s' with existing value '%s'."
                              % (str(v), str(k), params[k]))
@@ -304,9 +311,9 @@ class Job(object):
         ## \todo: CL option to disable automatic copying of ouput files.
         ##        The files should be symlinked if copying is disabled.
         # parser.add_argument("--no-copy-output-files", help="Disable copying of output files")
-        #parser.add_argument('--feature', dest='feature', action='store_true')
-        #parser.add_argument('--no-feature', dest='feature', action='store_false')
-        #parser.set_defaults(feature=True)
+        # parser.add_argument('--feature', dest='feature', action='store_true')
+        # parser.add_argument('--no-feature', dest='feature', action='store_false')
+        # parser.set_defaults(feature=True)
 
         cl = parser.parse_args(self.args)
 
@@ -320,7 +327,7 @@ class Job(object):
         try:
             self.log_level = logging.getLevelName(
                 self.job_config.parser.get('Job', 'log_level'))
-        except:
+        except BaseException:
             pass
 
         # Configure logging stream to file
@@ -353,12 +360,12 @@ class Job(object):
                 logger.debug('Changed stderr file to abs path: %s' % err_file)
             self.err = open(err_file, 'w')
 
-        #if cl.level:
+        # if cl.level:
         #    num_level = getattr(logging, cl.level.upper(), None)
         #    if not isinstance(num_level, int):
         #        raise ValueError('Invalid log level: %s' % num_level)
         #    logging.getLogger('hpsmc').setLevel(num_level)
-        #print("Set log level of hpsmc: %s" % logging.getLevelName(logging.getLogger('hpsmc').getEffectiveLevel()))
+        # print("Set log level of hpsmc: %s" % logging.getLevelName(logging.getLogger('hpsmc').getEffectiveLevel()))
 
         if cl.run_dir:
             self.rundir = cl.run_dir
@@ -400,7 +407,7 @@ class Job(object):
 
         self.set_parameters(params)
 
-        #logger.info(json.dumps(self.params, indent=4, sort_keys=False))
+        # logger.info(json.dumps(self.params, indent=4, sort_keys=False))
 
         if 'output_dir' in self.params:
             self.output_dir = self.params['output_dir']
@@ -417,11 +424,10 @@ class Job(object):
         if 'output_files' in self.params:
             self.output_files = self.params['output_files']
 
-
     def __set_input_files(self):
         """!
         Prepare dictionary of input files.
-        
+
         If a link to a download location is given as input, the file is downloaded into the run directory before the file name is added to the input_files dict. If a regular file is provided, it is added to the dict without any additional action.
         """
         input_files_dict = {}
@@ -435,7 +441,6 @@ class Job(object):
                 input_files_dict.update({file_key: file_name})
         self.input_files = input_files_dict
 
-
     def __initialize(self):
         """!
         Perform basic initialization before the job script is loaded.
@@ -444,7 +449,7 @@ class Job(object):
         if not os.path.isabs(self.rundir):
             self.rundir = os.path.abspath(self.rundir)
             logger.info('Changed run dir to abs path: %s' % self.rundir)
-            #raise Exception('The run dir is not an absolute path: %s' % self.rundir)
+            # raise Exception('The run dir is not an absolute path: %s' % self.rundir)
 
         # Set run dir if running inside LSF
         if "LSB_JOBID" in os.environ:
@@ -457,25 +462,24 @@ class Job(object):
             logger.info('Creating run dir: %s' % self.rundir)
             os.makedirs(self.rundir)
 
-
     def __configure(self):
         """!
         Configure job class and components.
         """
         # Configure job class
         self.job_config.config(self, require_section=False)
-        #allowed_names=Job._config_names,
+        # allowed_names=Job._config_names,
 
         # Configure each of the job components
         for c in self.components:
-            c.config(self.job_config.parser) # Configure from supplied config files
+            c.config(self.job_config.parser)  # Configure from supplied config files
             if self.enable_env_config:
                 c.config_from_environ()      # Configure from env vars, if enabled
             # TODO: catch exception here...
             c.check_config()                 # Check that the config is acceptable
 
     def _load_script(self):
-        """! 
+        """!
         Load the job script.
         """
         if not self.script.endswith('.py'):
@@ -650,12 +654,12 @@ class Job(object):
             logger.debug("Configuring file IO for component '%s' with order %d" % (component. name, i))
             if i == 0:
                 logger.debug("Setting inputs on '%s' to: %s"
-                            % (component.name, str(list(self.input_files.values()))))
+                             % (component.name, str(list(self.input_files.values()))))
                 if not len(component.inputs):
                     component.inputs = list(self.input_files.values())
             elif i > -1:
                 logger.debug("Setting inputs on '%s' to: %s"
-                            % (component.name, str(self.components[i - 1].output_files())))
+                             % (component.name, str(self.components[i - 1].output_files())))
                 if len(component.inputs) == 0:
                     component.inputs = self.components[i - 1].output_files()
 
@@ -695,7 +699,7 @@ class Job(object):
             logger.debug('Creating output dir: %s' % self.output_dir)
             os.makedirs(self.output_dir, 0o755)
 
-        for src,dest in self.output_files.items():
+        for src, dest in self.output_files.items():
             src_file = src
             if Job.is_ptag(src):
                 ptag_src = Job.get_ptag_from_src(src)
@@ -744,9 +748,9 @@ class Job(object):
         """!
         Copy input files to the run dir.
         """
-        for src,dest in self.input_files.items():
-            #if not os.path.isabs(src):
-                ## \todo FIXME: Could try and convert to abspath here.
+        for src, dest in self.input_files.items():
+            # if not os.path.isabs(src):
+            ## \todo FIXME: Could try and convert to abspath here.
             #    raise Exception("The input source file '%s' is not an absolute path." % src)
             if os.path.dirname(dest):
                 raise Exception("The input file destination '%s' is not valid." % dest)
@@ -764,7 +768,7 @@ class Job(object):
         """!
         Symlink input files.
         """
-        for src,dest in self.input_files.items():
+        for src, dest in self.input_files.items():
             if not os.path.isabs(src):
                 raise Exception('The input source file is not an absolute path: %s' % src)
             if os.path.dirname(dest):
@@ -776,15 +780,15 @@ class Job(object):
         """!
         Map a key to an output file name so a user can reference it in their job params.
         """
-        if not tag in list(self.ptags.keys()):
+        if tag not in list(self.ptags.keys()):
             self.ptags[tag] = filename
             logger.info("Added ptag %s -> %s" % (tag, filename))
         else:
             raise Exception('The ptag already exists: %s' % tag)
 
-    def __copy_ptag_output_files(self):  ## \todo is this still needed?
+    def __copy_ptag_output_files(self):  # \todo is this still needed?
         if len(self.ptags):
-            for src,dest in self.output_files.items():
+            for src, dest in self.output_files.items():
                 if Job.is_ptag(src):
                     ptag_src = Job.get_ptag_from_src(src)
                     if ptag_src in list(self.ptags.keys()):
@@ -811,16 +815,19 @@ class Job(object):
         else:
             return src
 
+
 cmds = {
     'run': 'Run a job script',
     'script': 'Show list of available job scripts (provide script name for detailed info)',
     'component': 'Show list of available components (provide component name for detailed info)'}
 
+
 def print_usage():
     print("Usage: job.py [command] [args]")
     print("    command:")
-    for name,descr in cmds.items():
-        print("        %s: %s" % (name,descr))
+    for name, descr in cmds.items():
+        print("        %s: %s" % (name, descr))
+
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:
@@ -854,4 +861,3 @@ if __name__ == '__main__':
 
     else:
         print_usage()
-

--- a/python/hpsmc/job_template.py
+++ b/python/hpsmc/job_template.py
@@ -12,21 +12,26 @@ import uuid as _uuid
 
 from jinja2 import Template, Environment, FileSystemLoader
 
+
 def basename(path):
     """! Filter to return a file base name stripped of dir and extension."""
     return os.path.splitext(os.path.basename(path))[0]
+
 
 def extension(path):
     """! Filter to get file extension from string."""
     return os.path.splitext(path)[1]
 
+
 def dirname(path):
     """! Filter to get dir name from string."""
     return os.path.dirname(path)
 
+
 def pad(num, npad=4):
     """! Filter to pad a number."""
     return format(num, format(npad, '02'))
+
 
 def uuid():
     """! Function to get a uuid within a template."""
@@ -35,8 +40,9 @@ def uuid():
 # TODO:
 # filenum filter - try to get file num by looking for _%d in file name
 
-#def pwd():
+# def pwd():
 #    return os.getcwd()
+
 
 class JobData(object):
     """! Very simple key-value object for storing data for each job."""
@@ -52,10 +58,13 @@ class JobData(object):
     def set_param(self, name, value):
         self.params[name] = value
 
+
 class MaxJobsException(Exception):
     """! Exception if max jobs are reached."""
+
     def __init__(self, max_jobs):
         super().__init__("Reached max jobs: {}".format(max_jobs))
+
 
 class JobTemplate:
     """! Template engine for transforming input job template into JSON job store.
@@ -105,9 +114,9 @@ class JobTemplate:
 
     def add_itervars(self, iter_dict):
         """! Add several iter variables at once.
-        @param iter_dict  new dict of iteration variables to be added 
+        @param iter_dict  new dict of iteration variables to be added
         """
-        for k,v in iter_dict.items():
+        for k, v in iter_dict.items():
             self.add_itervar(k, v)
 
     def add_itervars_json(self, json_file):
@@ -127,7 +136,7 @@ class JobTemplate:
             for k in sorted(self.itervars.keys()):
                 var_list.append(self.itervars[k])
         prod = itertools.product(*var_list)
-        return var_names,list(prod)
+        return var_names, list(prod)
 
     def run(self):
         """!
@@ -140,8 +149,8 @@ class JobTemplate:
             job_vars = {'job': job,
                         'job_id': job.job_id,
                         'sequence': job.sequence,
-                        'input_files': job.input_files }
-            for k,v in job.params.items():
+                        'input_files': job.input_files}
+            for k, v in job.params.items():
                 if k in job_vars:
                     raise Exception("Illegal variable name: {}".format(k))
                 job_vars[k] = v
@@ -267,8 +276,8 @@ class JobTemplate:
             with open(var_file, 'r') as f:
                 self.add_itervars(json.load(f))
 
+
 if __name__ == '__main__':
     job_tmpl = JobTemplate()
     job_tmpl.parse_args()
     job_tmpl.run()
-

--- a/python/hpsmc/run_params.py
+++ b/python/hpsmc/run_params.py
@@ -3,7 +3,7 @@
 import sys
 
 run_params = {
-    "aprime_mass": { # MeV
+    "aprime_mass": {  # MeV
         "1pt05": [15, 20, 30, 40, 50, 60, 70, 80, 90],
         "1pt1": [15, 20, 30, 40, 50, 60, 70, 80, 90, 100],
         "1pt92": [50, 75, 100],
@@ -15,7 +15,7 @@ run_params = {
         "4pt55": [75, 90, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150, 160, 170, 180, 190, 200],
         "6pt6": [50, 100, 200, 300, 400, 500, 600]
     },
-    "target_z": { # target thickness in cm
+    "target_z": {  # target thickness in cm
         "1pt1": 0.0004062,
         "1pt92": 0.0008,
         "1pt05": 0.0004062,
@@ -28,7 +28,7 @@ run_params = {
         "4pt55": 0.002,
         "6pt6": 0.000875
     },
-    "beam_energy": { # GeV | MeV
+    "beam_energy": {  # GeV | MeV
         "1pt1": 1100.00,
         "1pt92": 1920.00,
         "1pt05": 1056.00,
@@ -56,13 +56,15 @@ run_params = {
     }
 }
 
+
 class RunParameters:
 
-    def __init__(self, key, json_filename = None):
+    def __init__(self, key, json_filename=None):
         self.key = key
 
     def get(self, param_name):
         return run_params[param_name][self.key]
+
 
 if __name__ == "__main__":
 

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -15,12 +15,13 @@ import hpsmc.func as func
 
 logger = logging.getLogger("hpsmc.tools")
 
+
 class SLIC(Component):
     """!
     Run the SLIC Geant4 simulation.
 
-    Optional parameters are: **nevents**, **macros**, **run_number** \n 
-    Required parameters are: **detector** \n 
+    Optional parameters are: **nevents**, **macros**, **run_number** \n
+    Required parameters are: **detector** \n
     Required configurations are: **slic_dir**, **hps_fieldmaps_dir**, **detector_dir**
     """
 
@@ -145,7 +146,7 @@ class SLIC(Component):
     def required_config(self):
         """!
         Return list of required configurations.
-        
+
         Required configurations are: **slic_dir**, **hps_fieldmaps_dir**, **detector_dir**
         @return  list of required configurations
         """
@@ -162,12 +163,13 @@ class SLIC(Component):
         # SLIC needs to be run inside bash as the Geant4 setup script is a piece of #@$@#$.
         cl = 'bash -c ". %s && %s %s"' % (self.env_script, self.command, ' '.join(self.cmd_args()))
 
-        #logger.info("Executing '%s' with command: %s" % (self.name, cl))
+        # logger.info("Executing '%s' with command: %s" % (self.name, cl))
         proc = subprocess.Popen(cl, shell=True, stdout=log_out, stderr=log_err)
         proc.communicate()
         proc.wait()
 
         return proc.returncode
+
 
 class JobManager(Component):
     """!
@@ -175,7 +177,7 @@ class JobManager(Component):
 
     Input files have slcio format.
 
-    Required parameters are: **steering_files** \n 
+    Required parameters are: **steering_files** \n
     Optional parameters are: **detector**, **run_number**, **defs**
     """
 
@@ -316,9 +318,9 @@ class JobManager(Component):
             args.append("outputFile=" + os.path.splitext(self.output_files()[0])[0])
 
         if self.defs:
-            for k,v in self.defs.items():
+            for k, v in self.defs.items():
                 args.append("-D")
-                args.append(k+"="+str(v))
+                args.append(k + "=" + str(v))
 
         if not os.path.isfile(self.steering_file):
             args.append("-r")
@@ -354,18 +356,19 @@ class JobManager(Component):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: **detector**, **run_number**, **defs**
         @return list of optional parameters
         """
         return ['detector', 'run_number', 'defs']
 
+
 class HPSTR(Component):
     """!
     Run the hpstr analysis tool.
 
-    Required parameters are: **config_files** \n 
-    Optional parameters are: **year**, **is_data**, **nevents** \n 
+    Required parameters are: **config_files** \n
+    Optional parameters are: **year**, **is_data**, **nevents** \n
     Required configs are: **hpstr_install_dir**, **hpstr_base**
     """
 
@@ -401,7 +404,7 @@ class HPSTR(Component):
                 raise Exception('The config has a directory but is not an abs path: %s' % self.cfg)
         else:
             # Assume the cfg file is within the hpstr base dir.
-            self.cfg_path = os.path.join(self.hpstr_base, "processors",  "config", config_file)
+            self.cfg_path = os.path.join(self.hpstr_base, "processors", "config", config_file)
         logger.debug('Set config path: %s' % self.cfg_path)
 
         # For ROOT output, automatically append the cfg key from the job params.
@@ -453,7 +456,7 @@ class HPSTR(Component):
 
     def output_files(self):
         """! Adjust names of output files."""
-        f,ext = os.path.splitext(self.input_files()[0])
+        f, ext = os.path.splitext(self.input_files()[0])
         if '.slcio' in ext:
             return ['%s.root' % f]
         else:
@@ -473,6 +476,8 @@ class HPSTR(Component):
         return proc.returncode
 
 ## \todo split this over several files -> move stdheptools in separate package
+
+
 class StdHepTool(Component):
     """!
     Generic class for StdHep tools.
@@ -517,6 +522,7 @@ class StdHepTool(Component):
             raise Exception("No inputs specified for StdHepTool.")
 
         return args
+
 
 class BeamCoords(StdHepTool):
     """!
@@ -581,14 +587,15 @@ class BeamCoords(StdHepTool):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: **beam_sigma_x**, **beam_sigma_y**, **beam_rot_x**,
         **beam_rot_y**, **beam_rot_z**, **target_x**, **target_y**, **target_z**
         @return list of optional parameters
         """
-        return['beam_sigma_x', 'beam_sigma_y', 'beam_rot_x',
-               'beam_rot_y', 'beam_rot_z',
-               'target_x', 'target_y', 'target_z']
+        return ['beam_sigma_x', 'beam_sigma_y', 'beam_rot_x',
+                'beam_rot_y', 'beam_rot_z',
+                'target_x', 'target_y', 'target_z']
+
 
 class RandomSample(StdHepTool):
     """!
@@ -639,11 +646,11 @@ class RandomSample(StdHepTool):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: **nevents**, **mu**
         @return list of optional parameters
         """
-        return ['nevents','mu']
+        return ['nevents', 'mu']
 
     def execute(self, log_out, log_err):
         """! Execute RandomSample component"""
@@ -656,6 +663,7 @@ class RandomSample(StdHepTool):
         shutil.move(src, dest)
 
         return returncode
+
 
 class DisplaceTime(StdHepTool):
     """!
@@ -685,11 +693,12 @@ class DisplaceTime(StdHepTool):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: **ctau**
         @return list of optional parameters
         """
         return ['ctau']
+
 
 class DisplaceUni(StdHepTool):
     """!
@@ -719,24 +728,28 @@ class DisplaceUni(StdHepTool):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: **ctau**
         @return list of optional parameters
         """
         return ['ctau']
 
+
 class AddMother(StdHepTool):
     """!
     Add mother particles for physics samples.
     """
+
     def __init__(self, **kwargs):
         StdHepTool.__init__(self,
                             name='add_mother',
                             append_tok='mom',
                             **kwargs)
 
+
 class AddMotherFullTruth(StdHepTool):
     """! Add full truth mother particles for physics samples"""
+
     def __init__(self, **kwargs):
         StdHepTool.__init__(self,
                             'add_mother_full_truth',
@@ -745,11 +758,11 @@ class AddMotherFullTruth(StdHepTool):
         if len(self.inputs) != 2:
             raise Exception("Must have 2 input files: a stdhep file and a lhe file in order")
         self.input_file_1 = self.inputs[0]
-        base,ext = os.path.splitext(self.input_file_1)
+        base, ext = os.path.splitext(self.input_file_1)
         if ext != '.stdhep':
             raise Exception("The first input file must be a stdhep file")
         self.input_file_2 = self.inputs[1]
-        base,ext = os.path.splitext(self.input_file_2)
+        base, ext = os.path.splitext(self.input_file_2)
         if ext != '.lhe':
             raise Exception("The second input file must be a lhe file")
 
@@ -793,17 +806,16 @@ class MergePoisson(StdHepTool):
         """! Setup MergePoisson component."""
         self.run_param_data = RunParameters(self.run_params)
         ## \todo: this function could just be inlined here
-        if self.xsec>0:
+        if self.xsec > 0:
             self.mu = func.lint(self.run_param_data) * self.xsec
         else:
             raise Exception("Cross section is missing.")
         logger.info("mu is %f", self.mu)
-        
 
     def required_parameters(self):
         """!
         Return list of required parameters.
-        
+
         Required parameters are: **run_params**
         @return list of required parameters
         """
@@ -815,7 +827,7 @@ class MergePoisson(StdHepTool):
         @return  list of arguments
         """
         args = []
-        #self.mu = func.mu(self.lhe_file, self.run_param_data)
+        # self.mu = func.mu(self.lhe_file, self.run_param_data)
         if self.name in StdHepTool.seed_names:
             args.extend(["-s", str(self.seed)])
 
@@ -846,11 +858,12 @@ class MergePoisson(StdHepTool):
 
         return returncode
 
+
 class MergeFiles(StdHepTool):
     """!
     Merge StdHep files.
 
-    Optional parameters are: none \n 
+    Optional parameters are: none \n
     Required parameters are: none
     """
 
@@ -862,7 +875,7 @@ class MergeFiles(StdHepTool):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: none
         @return list of optional parameters
         """
@@ -871,11 +884,12 @@ class MergeFiles(StdHepTool):
     def required_parameters(self):
         """!
         Return list of required parameters.
-        
+
         Required parameters are: none
         @return list of required parameters
         """
         return []
+
 
 class StdHepCount(Component):
     """!
@@ -907,10 +921,12 @@ class StdHepCount(Component):
 
         return proc.returncode
 
+
 class JavaTool(Component):
     """!
     Generic base class for Java based tools.
     """
+
     def __init__(self, name, java_class, **kwargs):
         ## java class
         self.java_class = java_class
@@ -973,33 +989,34 @@ class EvioToLcio(JavaTool):
 
     Input files have evio format (format used by DAQ system).
 
-    Required parameters are: **detector**, **steering_files** \n 
+    Required parameters are: **detector**, **steering_files** \n
     Optional parameters are: **run_number**, **skip_events**, **nevents**, **event_print_interval**
     """
+
     def __init__(self, steering=None, **kwargs):
         ## detector name
-       self.detector = None
-       ## steering file
-       self.steering = None
-       ## run number
-       self.run_number = None
-       ## number of events that are skipped
-       self.skip_events = None
-       ## event print interval
-       self.event_print_interval = None
-       ## \todo is it necessary to set this twice?
-       self.steering = steering
+        self.detector = None
+        ## steering file
+        self.steering = None
+        ## run number
+        self.run_number = None
+        ## number of events that are skipped
+        self.skip_events = None
+        ## event print interval
+        self.event_print_interval = None
+        ## \todo is it necessary to set this twice?
+        self.steering = steering
 
-       JavaTool.__init__(self,
-                         name='evio_to_lcio',
-                         java_class='org.hps.evio.EvioToLcio',
-                         output_ext='.slcio',
-                         **kwargs)
+        JavaTool.__init__(self,
+                          name='evio_to_lcio',
+                          java_class='org.hps.evio.EvioToLcio',
+                          output_ext='.slcio',
+                          **kwargs)
 
     def required_parameters(self):
         """!
         Return list of required parameters.
-        
+
         Required parameters are: **detector**, **steering_files**
         @return list of required parameters
         """
@@ -1008,7 +1025,7 @@ class EvioToLcio(JavaTool):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: **run_number**, **skip_events**, **nevents**, **event_print_interval**
         @return list of optional parameters
         """
@@ -1058,14 +1075,16 @@ class EvioToLcio(JavaTool):
 
         return args
 
+
 class FilterBunches(JavaTool):
     """!
     Space MC events and apply energy filters to process before readout.
 
     Optional parameters are: **filter_ecal_hit_ecut**, **filter_event_interval**,
-    **filter_nevents_read**, **filter_nevents_write**, **filter_no_cuts** \n 
+    **filter_nevents_read**, **filter_nevents_write**, **filter_no_cuts** \n
     Required config are: **hps_java_bin_jar**
     """
+
     def __init__(self, **kwargs):
         if 'filter_no_cuts' in kwargs:
             self.filter_no_cuts = kwargs['filter_no_cuts']
@@ -1083,7 +1102,7 @@ class FilterBunches(JavaTool):
         else:
             # No default ecal hit cut energy (negative val to be ignored)
             self.filter_ecal_hit_ecut = -1.0
-            #self.filter_ecal_hit_ecut = 0.05
+            # self.filter_ecal_hit_ecut = 0.05
 
         if 'filter_event_interval' in kwargs:
             self.filter_event_interval = kwargs['filter_event_interval']
@@ -1148,9 +1167,9 @@ class FilterBunches(JavaTool):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: **filter_ecal_hit_ecut**, **filter_event_interval**,
-        **filter_nevents_read**, **filter_nevents_write**, **filter_no_cuts** \n 
+        **filter_nevents_read**, **filter_nevents_write**, **filter_no_cuts** \n
         @return list of optional parameters
         """
         return ['filter_ecal_hit_ecut',
@@ -1162,23 +1181,25 @@ class FilterBunches(JavaTool):
     def required_config(self):
         """!
         Return list of required config.
-        
+
         Required config are: **hps_java_bin_jar**
         @return list of required config
         """
         return ['hps_java_bin_jar']
 
+
 class ExtractEventsWithHitAtHodoEcal(JavaTool):
     """!
     Apply hodo-hit filter and space MC events to process before readout.
-    
+
     The nevents parameter is not settable from JSON in this class. It should
     be supplied as an init argument in the job script if it needs to be
     customized (the default nevents and event_interval used to apply spacing
-    should usually not need to be changed by the user). \n 
+    should usually not need to be changed by the user). \n
 
     Optional parameters are: **num_hodo_hits**, **event_interval**
     """
+
     def __init__(self, **kwargs):
         if "num_hodo_hits" in kwargs:
             self.num_hodo_hits = kwargs['num_hodo_hits']
@@ -1218,16 +1239,18 @@ class ExtractEventsWithHitAtHodoEcal(JavaTool):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: **num_hodo_hits**, **event_interval**
         @return list of optional parameters
         """
         return ['num_hodo_hits', 'event_interval']
 
+
 class Unzip(Component):
     """!
     Unzip the input files to outputs.
     """
+
     def __init__(self, **kwargs):
         Component.__init__(self,
                            name='unzip',
@@ -1247,13 +1270,15 @@ class Unzip(Component):
                 logger.debug("Unzipped '%s' to '%s'" % (inputfile, outputfile))
         return 0
 
+
 class LCIODumpEvent(Component):
     """!
     Dump LCIO event information.
 
-    Required parameters are: none \n 
+    Required parameters are: none \n
     Required config are: **lcio_dir**
     """
+
     def __init__(self, **kwargs):
         ## lcio directory
         self.lcio_dir = None
@@ -1292,7 +1317,7 @@ class LCIODumpEvent(Component):
     def required_config(self):
         """!
         Return list of required config.
-        
+
         Required config are: **lcio_dir**
         @return list of required config
         """
@@ -1301,16 +1326,18 @@ class LCIODumpEvent(Component):
     def required_parameters(self):
         """!
         Return list of required parameters.
-        
+
         Required parameters are: none
         @return list of required parameters
         """
         return []
 
+
 class LHECount(Component):
     """!
     Count events in an LHE file.
     """
+
     def __init__(self, minevents=0, fail_on_underflow=False, **kwargs):
         self.minevents = minevents
         Component.__init__(self,
@@ -1323,7 +1350,7 @@ class LHECount(Component):
             raise Exception("Missing at least one input file.")
 
     def cmd_exists(self):
-        """! 
+        """!
         Check if command exists.
         @return True if command exists
         """
@@ -1336,8 +1363,8 @@ class LHECount(Component):
                 lines = in_file.readlines()
 
             nevents = 0
-            for l in lines:
-                if "<event>" in l:
+            for line in lines:
+                if "<event>" in line:
                     nevents += 1
 
             print("LHE file '%s' has %d events." % (i, nevents))
@@ -1350,17 +1377,19 @@ class LHECount(Component):
                     logger.warning(msg)
         return 0
 
+
 class TarFiles(Component):
     """!
     Tar files into an archive.
     """
+
     def __init__(self, **kwargs):
         Component.__init__(self,
                            name='tar_files',
                            **kwargs)
 
     def cmd_exists(self):
-        """! 
+        """!
         Check if command exists.
         @return True if command exists
         """
@@ -1377,17 +1406,19 @@ class TarFiles(Component):
         logger.info("Wrote archive '%s'" % self.outputs[0])
         return 0
 
+
 class MoveFiles(Component):
     """!
     Move input files to new locations.
     """
+
     def __init__(self, **kwargs):
         Component.__init__(self,
                            name='move_files',
                            **kwargs)
 
     def cmd_exists(self):
-        """! 
+        """!
         Check if command exists.
         @return True if command exists
         """
@@ -1404,13 +1435,15 @@ class MoveFiles(Component):
             shutil.move(src, dest)
         return 0
 
+
 class LCIOTool(Component):
     """!
     Generic component for LCIO tools.
 
-    Required parameters are: none \n 
+    Required parameters are: none \n
     Required config are: **lcio_bin_jar**
     """
+
     def __init__(self, name=None, **kwargs):
         ## lcio bin jar (whatever this is)
         self.lcio_bin_jar = None
@@ -1435,7 +1468,7 @@ class LCIOTool(Component):
     def required_config(self):
         """!
         Return list of required config.
-        
+
         Required config are: **lcio_bin_jar**
         @return list of required config
         """
@@ -1444,16 +1477,18 @@ class LCIOTool(Component):
     def required_parameters(self):
         """!
         Return list of required parameters.
-        
+
         Required parameters are: none
         @return list of required parameters
         """
         return []
 
+
 class LCIOConcat(LCIOTool):
     """!
     Concatenate LCIO files together.
     """
+
     def __init__(self, **kwargs):
         LCIOTool.__init__(self,
                           name='concat',
@@ -1474,13 +1509,15 @@ class LCIOConcat(LCIOTool):
         args.extend(["-o", self.outputs[0]])
         return args
 
+
 class LCIOCount(LCIOTool):
     """!
     Count events in LCIO files.
 
-    Required parameters are: none \n 
+    Required parameters are: none \n
     Optional parameters are: none
     """
+
     def __init__(self, **kwargs):
         LCIOTool.__init__(self,
                           name='count',
@@ -1500,7 +1537,7 @@ class LCIOCount(LCIOTool):
     def required_parameters(self):
         """!
         Return list of required parameters.
-        
+
         Required parameters are: none
         @return list of required parameters
         """
@@ -1509,16 +1546,18 @@ class LCIOCount(LCIOTool):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: none
         @return list of optional parameters
         """
         return []
 
+
 class LCIOMerge(LCIOTool):
     """!
     Merge LCIO files.
     """
+
     def __init__(self, **kwargs):
         LCIOTool.__init__(self,
                           name='merge',
@@ -1541,12 +1580,13 @@ class LCIOMerge(LCIOTool):
             args.extend(['-n', str(self.nevents)])
         return args
 
+
 class SimBase(Component):
     """!
     Generic base class for shared Geant4 sim config
     \todo Make SLIC extend this, too.
 
-    Optional parameters are: **nevents**, **macros**, **run_number** \n 
+    Optional parameters are: **nevents**, **macros**, **run_number** \n
     Required parameters are: **detector**
     """
 
@@ -1557,7 +1597,7 @@ class SimBase(Component):
     def optional_parameters(self):
         """!
         Return list of optional parameters.
-        
+
         Optional parameters are: **nevents**, **macros**, **run_number**
         @return list of optional parameters
         """
@@ -1566,7 +1606,7 @@ class SimBase(Component):
     def required_parameters(self):
         """!
         Return list of required parameters.
-        
+
         Required parameters are: **detector**
         @return list of required parameters
         """
@@ -1583,12 +1623,14 @@ class SimBase(Component):
 
         return proc.returncode
 
+
 class Sim(SimBase):
     """!
     Run the hps-sim Geant4 simulation.
 
     Required config are: **hps_sim_dir**, **hps_fieldmaps_dir**, **detector_dir**
     """
+
     def __init__(self, **kwargs):
         ## List of macros to run (optional)
         self.macros = []
@@ -1670,7 +1712,7 @@ class Sim(SimBase):
 
         macro_lines.append("/hps/lcio/recreate")
         macro_lines.append("/hps/lcio/file {}".format(self.output_files()[0]))
-        
+
         macro_lines.append("/run/beamOn {}".format(self.nevents))
 
         ## \todo: Set run number (no Geant4 built-in for this?)
@@ -1681,7 +1723,7 @@ class Sim(SimBase):
     def required_config(self):
         """!
         Return list of required config.
-        
+
         Required config are: **hps_sim_dir**, **hps_fieldmaps_dir**, **detector_dir**
         @return list of required config
         """

--- a/python/hpsmc/util.py
+++ b/python/hpsmc/util.py
@@ -3,6 +3,7 @@
 import sys
 import logging
 
+
 def convert_config_value(val):
     """! Convert config value to Python readable value."""
     if val == 'True' or val == 'true':
@@ -13,24 +14,25 @@ def convert_config_value(val):
         if val.contains('.'):
             floatval = float(val)
             return floatval
-    except:
+    except BaseException:
         pass
     try:
         intval = int(val)
         return intval
-    except:
+    except BaseException:
         pass
     return val
+
 
 def config_logging(stream=sys.stdout, level=logging.DEBUG, logname='hpsmc'):
     """!
     Configure logging by setting an output stream and level (both optional).
     Any handlers already registered will be replaced by calling this method.
     """
-    #print("Config logging: " + str(stream) + " " + str(level) + " " + logname)
+    # print("Config logging: " + str(stream) + " " + str(level) + " " + logname)
     logger = logging.getLogger(logname)
     logger.propagate = False
-    logger.handlers = [] # Reset handlers in case this is called more than once
+    logger.handlers = []  # Reset handlers in case this is called more than once
     logger.setLevel(level)
     handler = logging.StreamHandler(stream)
     handler.setLevel(level)

--- a/python/jobs/ap_gen_to_slic_job.py
+++ b/python/jobs/ap_gen_to_slic_job.py
@@ -43,7 +43,7 @@ if ap_decay_dist == "lhe_uniform":
 elif ap_decay_dist == "lhe_prompt":
     ## Convert LHE output to stdhep for prompt signal
     cnv = StdHepConverter(name="lhe_prompt", inputs=["ap_unweighted_events.lhe"])
-elif ap_decay_dist == "displace_time": 
+elif ap_decay_dist == "displace_time":
     if 'ctau' in job.params:
         ## Displace the time of decay using the ctau param
         cnv = DisplaceUni(inputs=["ap_unweighted_events.lhe"])
@@ -59,7 +59,7 @@ mom = AddMotherFullTruth(inputs=["ap_unweighted_events.stdhep", unzip.output_fil
 rot = BeamCoords(inputs=mom.output_files(), outputs=["ap_rot.stdhep"])
 
 ## Simulate signal events
-slic = SLIC(nevents=nevents+1, inputs=rot.output_files(), outputs=["ap.slcio"])
+slic = SLIC(nevents=nevents + 1, inputs=rot.output_files(), outputs=["ap.slcio"])
 
 ## run the job
 job.add([mg, unzip, cnv, mom, rot, slic])

--- a/python/jobs/ap_slic_job.py
+++ b/python/jobs/ap_slic_job.py
@@ -38,7 +38,7 @@ elif ap_decay_dist == "lhe_prompt":
     ## Convert LHE output to stdhep for prompt signal
     cnv = StdHepConverter(name="lhe_prompt", inputs=["ap_unweighted_events.lhe"])
     job.add([cnv])
-elif ap_decay_dist == "displace_time": 
+elif ap_decay_dist == "displace_time":
     if 'ctau' in job.params:
         ## Displace the time of decay using the ctau param
         cnv = DisplaceUni(inputs=["ap_unweighted_events.lhe"])
@@ -55,7 +55,7 @@ mom = AddMotherFullTruth(inputs=["ap_displace.stdhep", unzip.output_files()[0]],
 rot = BeamCoords(inputs=mom.output_files(), outputs=["ap_rot.stdhep"])
 
 ## Simulate signal events
-slic = SLIC(nevents=nevents+1, inputs=rot.output_files(), outputs=["ap.slcio"])
+slic = SLIC(nevents=nevents + 1, inputs=rot.output_files(), outputs=["ap.slcio"])
 
 ## run the job
 job.add([unzip, mom, rot, slic])

--- a/python/jobs/beam_prep_and_slic_job.py
+++ b/python/jobs/beam_prep_and_slic_job.py
@@ -26,7 +26,7 @@ sample = RandomSample()
 
 ## Simulate detector response
 
-slic = SLIC(nevents=nevents*event_interval, ignore_job_params=['nevents'])
+slic = SLIC(nevents=nevents * event_interval, ignore_job_params=['nevents'])
 
 ## Run the job
 job.add([rot, sample, slic])

--- a/python/jobs/dummy_job.py
+++ b/python/jobs/dummy_job.py
@@ -7,4 +7,4 @@ from hpsmc.component import DummyComponent
 
 job.description = 'Dummy'
 
-job.add(DummyComponent())  
+job.add(DummyComponent())

--- a/python/jobs/fee_gen_to_recon_job.py
+++ b/python/jobs/fee_gen_to_recon_job.py
@@ -25,7 +25,7 @@ rot = BeamCoords()
 sample = RandomSample()
 
 ## Simulate events
-slic = SLIC(nevents=nevents+1)
+slic = SLIC(nevents=nevents + 1)
 
 ## Space signal events
 space_events = ExtractEventsWithHitAtHodoEcal(event_interval=250, num_hodo_hits=0)

--- a/python/jobs/hpstr_job.py
+++ b/python/jobs/hpstr_job.py
@@ -3,7 +3,7 @@
 
 HPSTR reconstruction and analysis.
 """
-from hpsmc.tools import HPSTR 
+from hpsmc.tools import HPSTR
 
 job.description = 'HPSTR recon and analysis'
 

--- a/python/jobs/readout_recon_job.py
+++ b/python/jobs/readout_recon_job.py
@@ -34,12 +34,12 @@ if filter_bunches:
     job.add([filtered])
 
 ## Run simulated events in readout to generate triggers
-readout=JobManager(steering='readout')
+readout = JobManager(steering='readout')
 
-count_readout=LCIOCount()
+count_readout = LCIOCount()
 
 ## Run physics reconstruction
-reco=JobManager(steering='recon')
+reco = JobManager(steering='recon')
 
 count_reco = LCIOCount()
 
@@ -50,4 +50,4 @@ cnv = HPSTR(cfg='recon')
 ana = HPSTR(cfg='ana')
 
 job.add([readout, count_readout, reco, count_reco, cnv])
-#, ana])
+# , ana])

--- a/python/jobs/readout_recon_job.py
+++ b/python/jobs/readout_recon_job.py
@@ -3,7 +3,8 @@
 
 Simulate pile-up, run readout, hps-java recon, and analysis.
 """
-import os, logging
+import os
+import logging
 from hpsmc.tools import JobManager, FilterBunches, LCIOCount, HPSTR
 
 ## Initialize logger with default level
@@ -33,12 +34,12 @@ if filter_bunches:
     job.add([filtered])
 
 ## Run simulated events in readout to generate triggers
-readout = JobManager(steering='readout')
+readout=JobManager(steering='readout')
 
-count_readout = LCIOCount()
+count_readout=LCIOCount()
 
 ## Run physics reconstruction
-reco = JobManager(steering='recon')
+reco=JobManager(steering='recon')
 
 count_reco = LCIOCount()
 

--- a/python/jobs/signal_beam_merge_to_recon_2016_job.py
+++ b/python/jobs/signal_beam_merge_to_recon_2016_job.py
@@ -6,10 +6,10 @@ job.description = 'signal-beam from merge to recon'
 inputs = list(job.input_files.values())
 
 # Input signal events (slcio format)
-signal_file_name = [] 
+signal_file_name = []
 
 # Input beam events (slcio format)
-beam_file_name = [] 
+beam_file_name = []
 
 for input in inputs:
     if "signal" in input:
@@ -34,18 +34,18 @@ signal_beam_name = 'signal-beam'
 
 # Filter and space signal events and catenate files before merging
 filter_events = FilterBunches(inputs=signal_file_name,
-                                               outputs=['%s_filt.slcio' % signal_name], 
-                                               filter_event_interval=250, filter_ecal_pairs=True,
-                                               filter_ecal_hit_ecut=0.1)
+                              outputs=['%s_filt.slcio' % signal_name],
+                              filter_event_interval=250, filter_ecal_pairs=True,
+                              filter_ecal_hit_ecut=0.1)
 
 # Count filtered events
 count_filter = LCIOCount(inputs=filter_events.output_files())
 
 # catenate beam files before merging
 catenate_beam = FilterBunches(inputs=beam_file_name,
-                               outputs=['%s_filt.slcio' % beam_name], 
-                               filter_event_interval=0, filter_ecal_pairs=False,
-			       filter_no_cuts=True, filter_ecal_hit_ecut=-0.1)
+                              outputs=['%s_filt.slcio' % beam_name],
+                              filter_event_interval=0, filter_ecal_pairs=False,
+                              filter_no_cuts=True, filter_ecal_hit_ecut=-0.1)
 
 # Count beam events
 count_beam = LCIOCount(inputs=catenate_beam.output_files())
@@ -74,7 +74,7 @@ recon = JobManager(steering='recon',
 
 # Print number of recon events
 count_recon = LCIOCount(inputs=recon.output_files())
- 
+
 # Add the components
-job.add([filter_events, count_filter, catenate_beam,count_beam, merge, 
+job.add([filter_events, count_filter, catenate_beam, count_beam, merge,
          count_merge, readout, count_readout, recon, count_recon])

--- a/python/jobs/signal_beam_merge_to_recon_job.py
+++ b/python/jobs/signal_beam_merge_to_recon_job.py
@@ -12,10 +12,10 @@ job.description = 'signal-beam from merge to recon'
 inputs = list(job.input_files.values())
 
 ## Input signal events (slcio format)
-signal_file_name = [] 
+signal_file_name = []
 
 ## Input beam events (slcio format)
-beam_file_name = [] 
+beam_file_name = []
 
 for input in inputs:
     if "signal" in input:
@@ -40,7 +40,7 @@ signal_beam_name = 'signal-beam'
 
 ## Filter and space signal events and catenate files before merging
 filter_events = ExtractEventsWithHitAtHodoEcal(inputs=signal_file_name,
-                                               outputs=['%s_filt.slcio' % signal_name], 
+                                               outputs=['%s_filt.slcio' % signal_name],
                                                event_interval=250, num_hodo_hits=1)
 
 ## Count filtered events
@@ -48,8 +48,8 @@ count_filter = LCIOCount(inputs=filter_events.output_files())
 
 ## catenate beam files before merging
 catenate_beam = ExtractEventsWithHitAtHodoEcal(inputs=beam_file_name,
-                               outputs=['%s_filt.slcio' % beam_name], 
-                               event_interval=0, num_hodo_hits=0)
+                                               outputs=['%s_filt.slcio' % beam_name],
+                                               event_interval=0, num_hodo_hits=0)
 
 ## Count beam events
 count_beam = LCIOCount(inputs=catenate_beam.output_files())
@@ -78,7 +78,7 @@ recon = JobManager(steering='recon',
 
 ## Print number of recon events
 count_recon = LCIOCount(inputs=recon.output_files())
- 
+
 ## Add the components
-job.add([filter_events, count_filter, catenate_beam,count_beam, merge, 
+job.add([filter_events, count_filter, catenate_beam, count_beam, merge,
          count_merge, readout, count_readout, recon, count_recon])

--- a/python/jobs/signal_pulser_overlay_to_recon_job.py
+++ b/python/jobs/signal_pulser_overlay_to_recon_job.py
@@ -60,9 +60,9 @@ overlay = JobManager(steering='overlay',
 
 # Space overlaid events
 space_overlay = FilterBunches(inputs=overlay.output_files(),
-                             filter_no_cuts=True,
-                             outputs=['%s_spaced.slcio' % signal_pulser_name],
-                             filter_event_interval=250)
+                              filter_no_cuts=True,
+                              outputs=['%s_spaced.slcio' % signal_pulser_name],
+                              filter_event_interval=250)
 
 # Print number of merged events
 count_space_overlay = LCIOCount(inputs=space_overlay.output_files())

--- a/python/jobs/sim_to_ana_job.py
+++ b/python/jobs/sim_to_ana_job.py
@@ -27,9 +27,9 @@ root_cnv = HPSTR(cfg='recon')
 ana = HPSTR(cfg='ana')
 
 ## Set persistency tags for output files
-base_name,ext = os.path.splitext(list(job.input_files.values())[0])
+base_name, ext = os.path.splitext(list(job.input_files.values())[0])
 job.ptag('recon', '{}_filt_readout_recon.slcio'.format(base_name))
 job.ptag('ana', '{}_filt_readout_recon_ana.root'.format(base_name))
- 
+
 ## Add job components
 job.add([sim, filter_bunches, readout, recon, root_cnv, ana])

--- a/python/jobs/simp_job.py
+++ b/python/jobs/simp_job.py
@@ -1,7 +1,7 @@
 """!
 @file simp_job.py
 
-Simulation of SIMPs, detector signals, and readout, followed by reconstruction. 
+Simulation of SIMPs, detector signals, and readout, followed by reconstruction.
 """
 from hpsmc.generators import MG5
 from hpsmc.tools import SLIC, JobManager, FilterBunches, BeamCoords, Unzip, DisplaceUni
@@ -34,6 +34,6 @@ readout = JobManager(steering='readout')
 
 ## Run physics reconstruction
 recon = JobManager(steering='recon')
- 
+
 ## Run the job
 job.add([mg, unzip, cnv, rot, slic, filter_bunches, readout, recon])

--- a/python/jobs/slic_job.py
+++ b/python/jobs/slic_job.py
@@ -26,7 +26,7 @@ else:
 ## Simulate events
 slic_outs = []
 for i in range(len(inputs)):
-    slic_outs.append(SLIC(inputs=[inputs[i]], outputs=[output_names[i]], nevents=nevents+1))
+    slic_outs.append(SLIC(inputs=[inputs[i]], outputs=[output_names[i]], nevents=nevents + 1))
 
 ## Run the job
 job.add(slic_outs)

--- a/python/jobs/slic_to_anaMC_job.py
+++ b/python/jobs/slic_to_anaMC_job.py
@@ -15,6 +15,6 @@ tuple = HPSTR(cfg='mcTuple')
 
 ## Run an analysis on the ROOT file
 ana = HPSTR(cfg='ana')
- 
+
 ## Add the components
 job.add([slic, tuple, ana])

--- a/python/jobs/slic_to_ana_job.py
+++ b/python/jobs/slic_to_ana_job.py
@@ -27,7 +27,7 @@ root_cnv = HPSTR(cfg='recon')
 ana = HPSTR(cfg='ana')
 
 ## Set persistency tags for output files
-base_name,ext = os.path.splitext(list(job.input_files.values())[0])
+base_name, ext = os.path.splitext(list(job.input_files.values())[0])
 job.ptag('recon', '{}_filt_readout_recon.slcio'.format(base_name))
 job.ptag('ana', '{}_filt_readout_recon_ana.root'.format(base_name))
 

--- a/python/jobs/slic_to_recon_job.py
+++ b/python/jobs/slic_to_recon_job.py
@@ -36,13 +36,13 @@ for i in range(len(inputs)):
     slic_file_names.append(slic_file)
 
 ## Simulate beam events
-slic_comps = [] 
+slic_comps = []
 for i in range(len(inputs)):
     slic_comps.append(SLIC(inputs=[inputs[i]],
                       outputs=[slic_file_names[i]],
-                      nevents=nevents*event_int,
+                      nevents=nevents * event_int,
                       ignore_job_params=['nevents'])
-                     )
+                      )
 
 ## concatenate beam events before merging
 cat_out_name = base_name + '_slic_cat.slcio'
@@ -61,7 +61,7 @@ recon_out_name = base_name + '_recon.slcio'
 recon = JobManager(steering='recon',
                    inputs=readout.output_files(),
                    outputs=[recon_out_name])
- 
+
 ## Add the components
 comps = slic_comps
 comps.extend([slic_cat, readout, recon])

--- a/python/jobs/tritrig_beam_slic_to_reco_job.py
+++ b/python/jobs/tritrig_beam_slic_to_reco_job.py
@@ -55,14 +55,14 @@ slic_beams = []
 for i in range(len(beam_file_names)):
     slic_beams.append(SLIC(inputs=[beam_file_names[i]],
                       outputs=[beam_slic_file_names[i]],
-                      nevents=nevents*250,
+                      nevents=nevents * 250,
                       ignore_job_params=['nevents'])
                       )
 
 ## concatonate beam events before merging
 slic_beam_cat = ExtractEventsWithHitAtHodoEcal(inputs=beam_slic_file_names,
-                                                   outputs=['beam_cat.slcio'],
-                                                   event_interval=0, num_hodo_hits=0)
+                                               outputs=['beam_cat.slcio'],
+                                               event_interval=0, num_hodo_hits=0)
 
 ## Merge signal and beam events
 merge = LCIOMerge(inputs=[filter_bunches.output_files()[0],
@@ -90,6 +90,7 @@ recon = JobManager(steering='recon',
 count_recon = LCIOCount(inputs=recon.output_files())
 
 comps = [slic, filter_bunches, count_filter]
-for i in range(len(slic_beams)): comps.append(slic_beams[i])
+for i in range(len(slic_beams)):
+    comps.append(slic_beams[i])
 comps.extend([slic_beam_cat, merge, count_merge, readout, count_readout, recon, count_recon])
 job.add(comps)

--- a/python/jobs/tritrig_sim_full_chain_job.py
+++ b/python/jobs/tritrig_sim_full_chain_job.py
@@ -20,7 +20,7 @@ rot = BeamCoords()
 
 ## \todo cleanup
 # Print results
-#p = StdHepTool(name="print_stdhep")
+# p = StdHepTool(name="print_stdhep")
 
 ## Simulate events
 sim = Sim()
@@ -46,6 +46,6 @@ job.ptag('sim', 'tritrig_unweighted_events_mom_rot.slcio')
 job.ptag('readout', 'tritrig_unweighted_events_mom_rot_filt_readout.slcio')
 job.ptag('recon', 'tritrig_unweighted_events_mom_rot_filt_readout_recon.slcio')
 job.ptag('ana', 'tritrig_unweighted_events_mom_rot_filt_readout_recon_ana.root')
- 
+
 ## Add job components
 job.add([mg, stdhep_cnv, mom, rot, sim, filter_bunches, readout, recon, root_cnv, ana])

--- a/python/jobs/tritrig_slic_full_chain_job.py
+++ b/python/jobs/tritrig_slic_full_chain_job.py
@@ -44,6 +44,6 @@ job.ptag('sim', 'tritrig_unweighted_events_mom_rot.slcio')
 job.ptag('readout', 'tritrig_unweighted_events_mom_rot_filt_readout.slcio')
 job.ptag('recon', 'tritrig_unweighted_events_mom_rot_filt_readout_recon.slcio')
 job.ptag('ana', 'tritrig_unweighted_events_mom_rot_filt_readout_recon_ana.root')
- 
+
 ## Add job components
 job.add([mg, stdhep_cnv, mom, rot, sim, filter_bunches, readout, recon, root_cnv, ana])

--- a/python/jobs/wab_gen_to_slic_job.py
+++ b/python/jobs/wab_gen_to_slic_job.py
@@ -27,7 +27,7 @@ mom = AddMother()
 rot = BeamCoords()
 
 ## Simulate signal events
-slic = SLIC(nevents=nevents+1)
+slic = SLIC(nevents=nevents + 1)
 
 ## run the job
 job.add([mg, cnv, mom, rot, slic])


### PR DESCRIPTION
New github action to ensure proper formatting of python code in `hps-mc`. This action will fail if the pushed code does not follow the **PEP 8 style conventions**.

To prevent this action from failing, you can check if your code is formatted correctly locally before pushing. This can be done using [pycodestyle](https://pycodestyle.pycqa.org/en/latest/intro.html#configuration), by navigating to the top directory of hps-mc and running
```bash
pycodestyle --ignore=E266,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --max-line-length=160 python/
```
which will display all formatting errors in `python/`. Before running this, make sure pycodestyle is installed on your machine. If you need to install it, you can do this by running
```bash
pip install --user pycodestyle
```

You can automate the style check by creating a git pre-commit hook. This will automatically check the formatting of all python files upon running `git commit`. To add the pre-commit hook, navigate to the `.git/hooks/` directory in `hps-mc`, create a pre-commit hook, and make it executable. If you already have pre-commit hooks, you can skip this step.
```bash
cd .git/hooks
touch pre-commit
chmod +x pre-commit
```
Then, add the following lines to `pre-commit`
```bash
#!/bin/sh
pycodestyle --ignore=E266,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --max-line-length=160 python/
```
 
To fix the formatting errors, you can either do this manually by navigating to the displayed files and making the necessary changes, or you can use [autopep8](https://pypi.org/project/autopep8/#installation) as follows. First, install autopep8:
```bash
pip install --user --upgrade autopep8
```
Then run
```bash
autopep8 --aggressive --aggressive --ignore=E266,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --in-place --max-line-length=160 --recursive python/
```
from the top of the `hps-mc` directory. Alternatively, run `format_python_code.sh`.
This will automatically fix (most) of the formatting issues. 

To preserve the Doxygen-style comments, it is necessary to disable the automatic formatting of comment blocks which means that you might need to fix those by hand.