### PR TITLE
adjust command to fix comment style

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ pip install --user --upgrade autopep8
 ```
 Then run
 ```bash
-autopep8 --aggressive --aggressive --ignore=E265,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --in-place --max-line-length=160 --recursive python/
+autopep8 --aggressive --aggressive --ignore=E265,E266,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --in-place --max-line-length=160 --recursive python/
 ```
 from the top of the `hps-mc` directory. Alternatively, run `format_python_code.sh`.
 This will automatically fix (most) of the formatting issues. 

--- a/format_python_code.sh
+++ b/format_python_code.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-autopep8 --aggressive --aggressive --ignore=E265,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --in-place --max-line-length=160 --recursive python/
+autopep8 --aggressive --aggressive --ignore=E265,E266,E501,E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505 --in-place --max-line-length=160 --recursive python/


### PR DESCRIPTION
I messed up somewhere again, but this should now be the actually working command to not change the comment style.