### PR TITLE
add check to output file copying

### DIFF
--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -7,6 +7,7 @@ import sys
 import json
 import time
 import shutil
+import filecmp
 import argparse
 import getpass
 import logging
@@ -740,7 +741,12 @@ class Job(object):
         # Copy the file to the destination dir if not already created by the job
         logger.info("Copying '%s' to '%s'" % (src_file, dest_file))
         if not samefile:
+            # shutil will throw and error if the copy obviously fails
             shutil.copyfile(src_file, dest_file)
+            # take the time to double-check that the copy is identical to the original
+            #   this catches any sneaky network-dropping related copy failures
+            if not filecmp.cmp(src_file, dest_file, shallow=False) :
+                raise Exception('Copy from '%s' to '%s' failed.' % (src_file, dest_file))
         else:
             logger.warning("Skipping copy of '%s' to '%s' because they are the same file!" % (src_file, dest_file))
 


### PR DESCRIPTION
This does a quick byte-by-byte comparison between the original output file in the run directory with the copy in the output directory to make sure that the copy didn't end early due to network-related filesystem issues.

I found this issue when scaling up hps-java jobs that produced mille binary data files. Two out of the 200 files produced were only partially copied to the output directory and no errors were reported in the log. I only found this out by comparing the originals in the scratch directory with the supposed copies in the output directory.

We _could_ make this optional, but a non-hierarchical comparison is so fast relative to the length of a job that I think we should leave it on all the time.