### PR TITLE
Improve fieldmap setup

### DIFF
--- a/python/hpsmc/component.py
+++ b/python/hpsmc/component.py
@@ -163,8 +163,7 @@ class Component(object):
             if p in params:
                 if p not in self.ignore_job_params:
                     setattr(self, p, params[p])
-                    self.logger.debug("%s:%s=%s [optional]"
-                                 % (self.name, p, params[p]))
+                    self.logger.debug("%s:%s=%s [optional]" % (self.name, p, params[p]))
                 else:
                     self.logger.debug("Ignored job param '%s'" % p)
 

--- a/python/hpsmc/component.py
+++ b/python/hpsmc/component.py
@@ -133,10 +133,10 @@ class Component(object):
         if parser.has_section(section_name):
             for name, value in parser.items(section_name):
                 setattr(self, name, convert_config_value(value))
-                logger.debug("%s:%s:%s=%s" % (self.name,
-                                              name,
-                                              getattr(self, name).__class__.__name__,
-                                              getattr(self, name)))
+                self.logger.debug("%s:%s:%s=%s" % (self.name,
+                                                   name,
+                                                   getattr(self, name).__class__.__name__,
+                                                   getattr(self, name)))
 
     def set_parameters(self, params):
         """! Set class attributes for the component based on JSON parameters.
@@ -154,19 +154,19 @@ class Component(object):
             else:
                 if p not in self.ignore_job_params:
                     setattr(self, p, params[p])
-                    logger.debug("%s:%s=%s [required]" % (self.name, p, params[p]))
+                    self.logger.debug("%s:%s=%s [required]" % (self.name, p, params[p]))
                 else:
-                    logger.debug("Ignored job param '%s'" % p)
+                    self.logger.debug("Ignored job param '%s'" % p)
 
         # Set optional parameters.
         for p in self.optional_parameters():
             if p in params:
                 if p not in self.ignore_job_params:
                     setattr(self, p, params[p])
-                    logger.debug("%s:%s=%s [optional]"
+                    self.logger.debug("%s:%s=%s [optional]"
                                  % (self.name, p, params[p]))
                 else:
-                    logger.debug("Ignored job param '%s'" % p)
+                    self.logger.debug("Ignored job param '%s'" % p)
 
     def required_parameters(self):
         """!
@@ -233,10 +233,10 @@ class Component(object):
         """! Configure component from environment variables which are just upper case
         versions of the required config names set in the shell environment."""
         for c in self.required_config():
-            logger.debug("Setting config '%s' from environ" % c)
+            self.logger.debug("Setting config '%s' from environ" % c)
             if c.upper() in os.environ:
                 setattr(self, c, os.environ[c.upper()])
-                logger.debug("Set config '%s=%s' from env var '%s'" % (c, getattr(self, c), c.upper()))
+                self.logger.debug("Set config '%s=%s' from env var '%s'" % (c, getattr(self, c), c.upper()))
             else:
                 raise Exception("Missing config in environ for '%s'" % c)
 

--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -771,7 +771,7 @@ class Job(object):
         else:
             return src
 
-    def _config_fieldmap_dir(self): 
+    def _config_fieldmap_dir(self):
         """!
         Set fieldmap dir to install location if not provided in config
         """
@@ -796,6 +796,7 @@ class Job(object):
                 logger.debug("Fieldmap symlink or directory already exists: {}".format(fieldmap_symlink))
             else:
                 raise Exception("A file called 'fieldmap' exists but it is not a symlink or directory!")
+
 
 cmds = {
     'run': 'Run a job script',

--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -15,6 +15,7 @@ import configparser
 import glob
 import subprocess
 import copy
+import pathlib
 
 from collections.abc import Sequence
 from os.path import expanduser
@@ -177,6 +178,10 @@ class Job(object):
 
     def __init__(self, args=sys.argv, **kwargs):
 
+        if 'HPSMC_DIR' not in os.environ:
+            raise Exception('HPSMC_DIR is not set in the environment.')
+        self.hpsmc_dir = os.environ['HPSMC_DIR']
+
         ## (passed) job arguments
         self.args = args
         ## Job configuration
@@ -209,6 +214,8 @@ class Job(object):
         self.script = None
         ## job steps
         self.job_steps = None
+        ## fieldmap dir
+        self.hps_fieldmaps_dir = None
 
         ## These attributes can all be set in the config file.
         self.enable_copy_output_files = True
@@ -395,6 +402,9 @@ class Job(object):
         # Configure job class
         self.job_config.config(self, require_section=False)
 
+        # Configure the location of the fieldmap directory
+        self._config_fieldmap()
+
         # Configure each of the job components
         for component in self.components:
 
@@ -569,6 +579,9 @@ class Job(object):
         # Change to run dir
         logger.info('Changing to run dir: %s' % self.rundir)
         os.chdir(self.rundir)
+              
+        # Symlink the fieldmap directory
+        self._symlink_fieldmap_dir()
 
         # Limit components according to job steps
         if self.job_steps is not None:
@@ -586,7 +599,7 @@ class Job(object):
             component.setup()
             if self.check_commands and not component.cmd_exists():
                 raise Exception("Command '%s' does not exist for '%s'." % (component.command, component.name))
-
+            
     def _config_file_pipeline(self):
         """!
         Pipe component outputs to inputs automatically.
@@ -759,6 +772,28 @@ class Job(object):
         else:
             return src
 
+    def _symlink_fieldmap_dir(self):
+        fieldmap_symlink = pathlib.Path(os.getcwd(), "fieldmap")
+        if not fieldmap_symlink.exists():
+            logger.debug("Creating symlink to fieldmap directory: {}".format(fieldmap_symlink))
+            os.symlink(self.hps_fieldmaps_dir, "fieldmap")
+        else:
+            if fieldmap_symlink.is_dir() or os.path.islink(fieldmap_symlink):
+                self.logger.debug("Fieldmap symlink or directory already exists: {}".format(fieldmap_symlink))
+            else:
+                raise Exception("A file called 'fieldmap' exists but it is not a symlink or directory!")
+
+    def _config_fieldmap(self):
+        """!
+        Set fieldmap dir to install location if not provided in config
+        """
+        if self.hps_fieldmaps_dir is None:
+            self.hps_fieldmaps_dir = "{}/share/fieldmap".format(self.hpsmc_dir)
+            if not os.path.isdir(self.hps_fieldmaps_dir):
+                raise Exception("The fieldmaps dir does not exist: {}".format(self.hps_fieldmaps_dir))
+            logger.info("Using fieldmap dir from HPSMC installation: {}".format(self.hps_fieldmaps_dir))
+        else:
+            logger.info("Using fieldmap dir from config: {}".format(self.hps_fieldmaps_dir))
 
 cmds = {
     'run': 'Run a job script',

--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -15,6 +15,7 @@ import configparser
 import glob
 import subprocess
 import copy
+import pathlib
 
 from collections.abc import Sequence
 from os.path import expanduser
@@ -177,6 +178,10 @@ class Job(object):
 
     def __init__(self, args=sys.argv, **kwargs):
 
+        if 'HPSMC_DIR' not in os.environ:
+            raise Exception('HPSMC_DIR is not set in the environ.')
+        self.hpsmc_dir = os.environ['HPSMC_DIR']
+
         ## (passed) job arguments
         self.args = args
         ## Job configuration
@@ -209,6 +214,8 @@ class Job(object):
         self.script = None
         ## job steps
         self.job_steps = None
+        ## fieldmaps dir
+        self.hps_fieldmaps_dir = None
 
         ## These attributes can all be set in the config file.
         self.enable_copy_output_files = True
@@ -395,6 +402,9 @@ class Job(object):
         # Configure job class
         self.job_config.config(self, require_section=False)
 
+        # Configure the location of the fieldmap files
+        self._config_fieldmap_dir()
+
         # Configure each of the job components
         for component in self.components:
 
@@ -569,6 +579,9 @@ class Job(object):
         # Change to run dir
         logger.info('Changing to run dir: %s' % self.rundir)
         os.chdir(self.rundir)
+
+        # Create a symlink to the fieldmap directory
+        self._symlink_fieldmap_dir()
 
         # Limit components according to job steps
         if self.job_steps is not None:
@@ -759,6 +772,31 @@ class Job(object):
         else:
             return src
 
+    def _config_fieldmap_dir(self): 
+        """!
+        Set fieldmap dir to install location if not provided in config
+        """
+        if self.hps_fieldmaps_dir is None:
+            self.hps_fieldmaps_dir = "{}/share/fieldmap".format(self.hpsmc_dir)
+            if not os.path.isdir(self.hps_fieldmaps_dir):
+                raise Exception("The fieldmaps dir does not exist: {}".format(self.hps_fieldmaps_dir))
+            logger.debug("Using fieldmap dir from install: {}".format(self.hps_fieldmaps_dir))
+        else:
+            logger.debug("Using fieldmap dir from config: {}".format(self.hps_fieldmaps_dir))
+
+    def _symlink_fieldmap_dir(self):
+        """!
+        Symlink to the fieldmap directory
+        """
+        fieldmap_symlink = pathlib.Path(os.getcwd(), "fieldmap")
+        if not fieldmap_symlink.exists():
+            logger.debug("Creating symlink to fieldmap directory: {}".format(fieldmap_symlink))
+            os.symlink(self.hps_fieldmaps_dir, "fieldmap")
+        else:
+            if fieldmap_symlink.is_dir() or os.path.islink(fieldmap_symlink):
+                logger.debug("Fieldmap symlink or directory already exists: {}".format(fieldmap_symlink))
+            else:
+                raise Exception("A file called 'fieldmap' exists but it is not a symlink or directory!")
 
 cmds = {
     'run': 'Run a job script',

--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -15,7 +15,6 @@ import configparser
 import glob
 import subprocess
 import copy
-import pathlib
 
 from collections.abc import Sequence
 from os.path import expanduser
@@ -178,10 +177,6 @@ class Job(object):
 
     def __init__(self, args=sys.argv, **kwargs):
 
-        if 'HPSMC_DIR' not in os.environ:
-            raise Exception('HPSMC_DIR is not set in the environment.')
-        self.hpsmc_dir = os.environ['HPSMC_DIR']
-
         ## (passed) job arguments
         self.args = args
         ## Job configuration
@@ -214,8 +209,6 @@ class Job(object):
         self.script = None
         ## job steps
         self.job_steps = None
-        ## fieldmap dir
-        self.hps_fieldmaps_dir = None
 
         ## These attributes can all be set in the config file.
         self.enable_copy_output_files = True
@@ -402,9 +395,6 @@ class Job(object):
         # Configure job class
         self.job_config.config(self, require_section=False)
 
-        # Configure the location of the fieldmap directory
-        self._config_fieldmap()
-
         # Configure each of the job components
         for component in self.components:
 
@@ -579,9 +569,6 @@ class Job(object):
         # Change to run dir
         logger.info('Changing to run dir: %s' % self.rundir)
         os.chdir(self.rundir)
-              
-        # Symlink the fieldmap directory
-        self._symlink_fieldmap_dir()
 
         # Limit components according to job steps
         if self.job_steps is not None:
@@ -599,7 +586,7 @@ class Job(object):
             component.setup()
             if self.check_commands and not component.cmd_exists():
                 raise Exception("Command '%s' does not exist for '%s'." % (component.command, component.name))
-            
+
     def _config_file_pipeline(self):
         """!
         Pipe component outputs to inputs automatically.
@@ -772,28 +759,6 @@ class Job(object):
         else:
             return src
 
-    def _symlink_fieldmap_dir(self):
-        fieldmap_symlink = pathlib.Path(os.getcwd(), "fieldmap")
-        if not fieldmap_symlink.exists():
-            logger.debug("Creating symlink to fieldmap directory: {}".format(fieldmap_symlink))
-            os.symlink(self.hps_fieldmaps_dir, "fieldmap")
-        else:
-            if fieldmap_symlink.is_dir() or os.path.islink(fieldmap_symlink):
-                self.logger.debug("Fieldmap symlink or directory already exists: {}".format(fieldmap_symlink))
-            else:
-                raise Exception("A file called 'fieldmap' exists but it is not a symlink or directory!")
-
-    def _config_fieldmap(self):
-        """!
-        Set fieldmap dir to install location if not provided in config
-        """
-        if self.hps_fieldmaps_dir is None:
-            self.hps_fieldmaps_dir = "{}/share/fieldmap".format(self.hpsmc_dir)
-            if not os.path.isdir(self.hps_fieldmaps_dir):
-                raise Exception("The fieldmaps dir does not exist: {}".format(self.hps_fieldmaps_dir))
-            logger.info("Using fieldmap dir from HPSMC installation: {}".format(self.hps_fieldmaps_dir))
-        else:
-            logger.info("Using fieldmap dir from config: {}".format(self.hps_fieldmaps_dir))
 
 cmds = {
     'run': 'Run a job script',

--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -11,7 +11,6 @@ import filecmp
 import argparse
 import getpass
 import logging
-import configparser
 import glob
 import subprocess
 import copy

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -92,16 +92,7 @@ class SLIC(Component):
             if not os.path.isdir(self.detector_dir):
                 raise Exception('Failed to find valid detector_dir')
             self.logger.debug("Using detector_dir from install: {}".format(self.detector_dir))
-
-        # Set fieldmap dir to install location if not provided in config
-        if self.hps_fieldmaps_dir is None:
-            self.hps_fieldmaps_dir = "{}/share/fieldmap".format(self.hpsmc_dir)
-            if not os.path.isdir(self.hps_fieldmaps_dir):
-                raise Exception("The fieldmaps dir does not exist: {}".format(self.hps_fieldmaps_dir))
-            self.logger.debug("Using fieldmap dir from install: {}".format(self.hps_fieldmaps_dir))
-        else:
-            self.logger.debug("Using fieldmap dir from config: {}".format(self.hps_fieldmaps_dir))
-
+       
     def setup(self):
         """! Setup SLIC component."""
         if not os.path.exists(self.slic_dir):
@@ -110,17 +101,7 @@ class SLIC(Component):
         self.env_script = self.slic_dir + os.sep + "bin" + os.sep + "slic-env.sh"
         if not os.path.exists(self.env_script):
             raise Exception('SLIC setup script does not exist: %s' % self.name)
-
-        fieldmap_symlink = pathlib.Path(os.getcwd(), "fieldmap")
-        if not fieldmap_symlink.exists():
-            self.logger.debug("Creating symlink to fieldmap directory: {}".format(fieldmap_symlink))
-            os.symlink(self.hps_fieldmaps_dir, "fieldmap")
-        else:
-            if fieldmap_symlink.is_dir() or os.path.islink(fieldmap_symlink):
-                self.logger.debug("Fieldmap symlink or directory already exists: {}".format(fieldmap_symlink))
-            else:
-                raise Exception("A file called 'fieldmap' exists but it is not a symlink or directory!")
-
+       
         if self.run_number is not None:
             run_number_cmd = "/lcio/runNumber %d" % self.run_number
             run_number_mac = open("run_number.mac", 'w')
@@ -152,7 +133,7 @@ class SLIC(Component):
         Required configurations are: **slic_dir**, **hps_fieldmaps_dir**, **detector_dir**
         @return  list of required configurations
         """
-        return ['slic_dir', 'hps_fieldmaps_dir', 'detector_dir']
+        return ['slic_dir', 'detector_dir']
 
     def execute(self, log_out, log_err):
         """!

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -25,7 +25,7 @@ class SLIC(Component):
         ## List of macros to run (optional)
         self.macros = []
         ## Run number to set on output file (optional)
-        self.run_number = None       
+        self.run_number = None
         ## To be set from config or install dir
         self.detector_dir = None
 
@@ -88,7 +88,7 @@ class SLIC(Component):
             if not os.path.isdir(self.detector_dir):
                 raise Exception('Failed to find valid detector_dir')
             self.logger.debug("Using detector_dir from install: {}".format(self.detector_dir))
-        
+
     def setup(self):
         """! Setup SLIC component."""
         if not os.path.exists(self.slic_dir):
@@ -218,7 +218,7 @@ class JobManager(Component):
             if os.getenv("CONDITIONS_URL", None) is not None:
                 self.conditions_url = os.getenv("CONDITIONS_URL", None)
                 self.logger.debug('Set CONDITIONS_URL from environment: {}'.format(self.hps_java_bin_jar))
-        
+
     def required_config(self):
         """!
         Return list of required configurations.
@@ -943,6 +943,7 @@ class JavaTool(Component):
 
     def config(self, parser):
         super().config(parser)
+
 
 class EvioToLcio(JavaTool):
     """!

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -3,10 +3,8 @@
 import os
 import gzip
 import shutil
-import logging
 import subprocess
 import tarfile
-import pathlib
 
 from subprocess import PIPE
 
@@ -20,7 +18,7 @@ class SLIC(Component):
 
     Optional parameters are: **nevents**, **macros**, **run_number** \n
     Required parameters are: **detector** \n
-    Required configurations are: **slic_dir**, **hps_fieldmaps_dir**, **detector_dir**
+    Required configurations are: **slic_dir**, **detector_dir**
     """
 
     def __init__(self, **kwargs):
@@ -128,7 +126,7 @@ class SLIC(Component):
         """!
         Return list of required configurations.
 
-        Required configurations are: **slic_dir**, **hps_fieldmaps_dir**, **detector_dir**
+        Required configurations are: **slic_dir**, **detector_dir**
         @return  list of required configurations
         """
         return ['slic_dir', 'detector_dir']
@@ -220,22 +218,15 @@ class JobManager(Component):
             if os.getenv("CONDITIONS_URL", None) is not None:
                 self.conditions_url = os.getenv("CONDITIONS_URL", None)
                 self.logger.debug('Set CONDITIONS_URL from environment: {}'.format(self.hps_java_bin_jar))
-        if self.hps_fieldmaps_dir is None:
-            self.hps_fieldmaps_dir = "{}/share/fieldmap".format(self.hpsmc_dir)
-            if not os.path.isdir(self.hps_fieldmaps_dir):
-                raise Exception("The fieldmaps dir does not exist: {}".format(self.hps_fieldmaps_dir))
-            self.logger.debug("Using fieldmap dir from install: {}".format(self.hps_fieldmaps_dir))
-        else:
-            self.logger.debug("Using fieldmap dir from config: {}".format(self.hps_fieldmaps_dir))
-
+        
     def required_config(self):
         """!
         Return list of required configurations.
 
-        Required configurations are: **hps_java_bin_jar**, **hps_fieldmaps_dir**
+        Required configurations are: **hps_java_bin_jar**
         @retun list of required configurations.
         """
-        return ['hps_java_bin_jar', 'hps_fieldmaps_dir']
+        return ['hps_java_bin_jar']
 
     def setup(self):
         """! Setup JobManager component."""
@@ -928,10 +919,10 @@ class JavaTool(Component):
         """!
         Return list of required config.
 
-        Required config are: **hps_java_bin_jar**, **hps_fieldmaps_dir**
+        Required config are: **hps_java_bin_jar**
         @return list of required config
         """
-        return ['hps_java_bin_jar', 'hps_fieldmaps_dir']
+        return ['hps_java_bin_jar']
 
     def cmd_args(self):
         """!
@@ -952,21 +943,6 @@ class JavaTool(Component):
 
     def config(self, parser):
         super().config(parser)
-        if self.hps_fieldmaps_dir is None:
-            self.hps_fieldmaps_dir = "{}/share/fieldmap".format(self.hpsmc_dir)
-            if not os.path.isdir(self.hps_fieldmaps_dir):
-                raise Exception("The fieldmaps dir does not exist: {}".format(self.hps_fieldmaps_dir))
-            self.logger.debug("Using fieldmap dir from install: {}".format(self.hps_fieldmaps_dir))
-        else:
-            self.logger.debug("Using fieldmap dir from config: {}".format(self.hps_fieldmaps_dir))
-
-    def setup(self):
-        self.logger.debug('Creating sym link to fieldmap dir: {}'.format(self.hps_fieldmaps_dir))
-        if not os.path.islink(os.getcwd() + os.path.sep + "fieldmap"):
-            os.symlink(self.hps_fieldmaps_dir, "fieldmap")
-        else:
-            self.logger.warning('Link to fieldmap dir already exists!')
-
 
 class EvioToLcio(JavaTool):
     """!

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -27,9 +27,7 @@ class SLIC(Component):
         ## List of macros to run (optional)
         self.macros = []
         ## Run number to set on output file (optional)
-        self.run_number = None
-        ## To be set from config or install dir
-        self.hps_fieldmaps_dir = None
+        self.run_number = None       
         ## To be set from config or install dir
         self.detector_dir = None
 
@@ -92,16 +90,7 @@ class SLIC(Component):
             if not os.path.isdir(self.detector_dir):
                 raise Exception('Failed to find valid detector_dir')
             self.logger.debug("Using detector_dir from install: {}".format(self.detector_dir))
-
-        # Set fieldmap dir to install location if not provided in config
-        if self.hps_fieldmaps_dir is None:
-            self.hps_fieldmaps_dir = "{}/share/fieldmap".format(self.hpsmc_dir)
-            if not os.path.isdir(self.hps_fieldmaps_dir):
-                raise Exception("The fieldmaps dir does not exist: {}".format(self.hps_fieldmaps_dir))
-            self.logger.debug("Using fieldmap dir from install: {}".format(self.hps_fieldmaps_dir))
-        else:
-            self.logger.debug("Using fieldmap dir from config: {}".format(self.hps_fieldmaps_dir))
-
+        
     def setup(self):
         """! Setup SLIC component."""
         if not os.path.exists(self.slic_dir):
@@ -110,16 +99,6 @@ class SLIC(Component):
         self.env_script = self.slic_dir + os.sep + "bin" + os.sep + "slic-env.sh"
         if not os.path.exists(self.env_script):
             raise Exception('SLIC setup script does not exist: %s' % self.name)
-
-        fieldmap_symlink = pathlib.Path(os.getcwd(), "fieldmap")
-        if not fieldmap_symlink.exists():
-            self.logger.debug("Creating symlink to fieldmap directory: {}".format(fieldmap_symlink))
-            os.symlink(self.hps_fieldmaps_dir, "fieldmap")
-        else:
-            if fieldmap_symlink.is_dir() or os.path.islink(fieldmap_symlink):
-                self.logger.debug("Fieldmap symlink or directory already exists: {}".format(fieldmap_symlink))
-            else:
-                raise Exception("A file called 'fieldmap' exists but it is not a symlink or directory!")
 
         if self.run_number is not None:
             run_number_cmd = "/lcio/runNumber %d" % self.run_number
@@ -152,7 +131,7 @@ class SLIC(Component):
         Required configurations are: **slic_dir**, **hps_fieldmaps_dir**, **detector_dir**
         @return  list of required configurations
         """
-        return ['slic_dir', 'hps_fieldmaps_dir', 'detector_dir']
+        return ['slic_dir', 'detector_dir']
 
     def execute(self, log_out, log_err):
         """!
@@ -266,12 +245,6 @@ class JobManager(Component):
         if self.steering not in self.steering_files:
             raise Exception("Steering '%s' not found in: %s" % (self.steering, self.steering_files))
         self.steering_file = self.steering_files[self.steering]
-
-        self.logger.debug('Creating sym link to fieldmap dir: {}'.format(self.hps_fieldmaps_dir))
-        if not os.path.islink(os.getcwd() + os.path.sep + "fieldmap"):
-            os.symlink(self.hps_fieldmaps_dir, "fieldmap")
-        else:
-            self.logger.warning('Link to fieldmap dir already exists!')
 
     def cmd_args(self):
         """!

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -92,7 +92,16 @@ class SLIC(Component):
             if not os.path.isdir(self.detector_dir):
                 raise Exception('Failed to find valid detector_dir')
             self.logger.debug("Using detector_dir from install: {}".format(self.detector_dir))
-       
+
+        # Set fieldmap dir to install location if not provided in config
+        if self.hps_fieldmaps_dir is None:
+            self.hps_fieldmaps_dir = "{}/share/fieldmap".format(self.hpsmc_dir)
+            if not os.path.isdir(self.hps_fieldmaps_dir):
+                raise Exception("The fieldmaps dir does not exist: {}".format(self.hps_fieldmaps_dir))
+            self.logger.debug("Using fieldmap dir from install: {}".format(self.hps_fieldmaps_dir))
+        else:
+            self.logger.debug("Using fieldmap dir from config: {}".format(self.hps_fieldmaps_dir))
+
     def setup(self):
         """! Setup SLIC component."""
         if not os.path.exists(self.slic_dir):
@@ -101,7 +110,17 @@ class SLIC(Component):
         self.env_script = self.slic_dir + os.sep + "bin" + os.sep + "slic-env.sh"
         if not os.path.exists(self.env_script):
             raise Exception('SLIC setup script does not exist: %s' % self.name)
-       
+
+        fieldmap_symlink = pathlib.Path(os.getcwd(), "fieldmap")
+        if not fieldmap_symlink.exists():
+            self.logger.debug("Creating symlink to fieldmap directory: {}".format(fieldmap_symlink))
+            os.symlink(self.hps_fieldmaps_dir, "fieldmap")
+        else:
+            if fieldmap_symlink.is_dir() or os.path.islink(fieldmap_symlink):
+                self.logger.debug("Fieldmap symlink or directory already exists: {}".format(fieldmap_symlink))
+            else:
+                raise Exception("A file called 'fieldmap' exists but it is not a symlink or directory!")
+
         if self.run_number is not None:
             run_number_cmd = "/lcio/runNumber %d" % self.run_number
             run_number_mac = open("run_number.mac", 'w')
@@ -133,7 +152,7 @@ class SLIC(Component):
         Required configurations are: **slic_dir**, **hps_fieldmaps_dir**, **detector_dir**
         @return  list of required configurations
         """
-        return ['slic_dir', 'detector_dir']
+        return ['slic_dir', 'hps_fieldmaps_dir', 'detector_dir']
 
     def execute(self, log_out, log_err):
         """!


### PR DESCRIPTION
Configure fieldmap location and setup the symlink in the ```Job``` class instead of individual components, where it was heavily duplicated. 

If a custom location is needed then use this new configuration in ```Job``` rather than individual components:

```
[Job]
hps_fieldmaps_dir = /path/to/my/fieldmaps
``` 

I tested these changes with ```examples/tritrig_slic_full_chain```, and both SLIC and Java-based components seem to work fine with it.

This includes the changes from [this PR](https://github.com/JeffersonLab/hps-mc/pull/359) so it should be approved/merged first. Or it can be closed without merging if this one is merged instead.