### PR TITLE
deduce layer number and Ax/St from sensor name

### DIFF
--- a/python/hpsmc/alignment/_apply.py
+++ b/python/hpsmc/alignment/_apply.py
@@ -276,7 +276,9 @@ class ApplyPedeRes(_DetectorEditor):
 Compact updated by applying results from a run of pede
 
 ### Parameters Floated
+```json
 {json.dumps(self.to_float, indent = 2)}
+```
 
 """)
         return 0
@@ -357,7 +359,9 @@ class WriteMisalignedDet(_DetectorEditor):
 Detector written by applying an intentional misalignment to {self.detector}.
 
 ### Misalignment Applied
+```json
 {json.dumps(self.parameters, indent=2)}
+```
 
 """)
 

--- a/python/hpsmc/alignment/_apply.py
+++ b/python/hpsmc/alignment/_apply.py
@@ -190,7 +190,7 @@ class _DetectorEditor(Component):
         self.logger.info(f'Updating README.md at {log_path}')
         with open(log_path, 'a') as log:
             from datetime import datetime
-            log.write(f'# {detname}\n')
+            log.write(f'\n# {detname}\n')
             log.write(msg)
             log.write(f'_auto-generated note on {str(datetime.now())}_\n')
             log.flush()  # need manual flush since we leave after this

--- a/python/hpsmc/alignment/_parameter.py
+++ b/python/hpsmc/alignment/_parameter.py
@@ -71,7 +71,7 @@ class Parameter:
         """
 
         m = Parameter.layer_number_pattern.match(self._name)
-        if m is None :
+        if m is None:
             raise ValueError(f'Unable to deduce layer number from name {self.name}')
 
         return int(m.group(1))

--- a/python/hpsmc/alignment/_parameter.py
+++ b/python/hpsmc/alignment/_parameter.py
@@ -66,8 +66,10 @@ class Parameter:
     def layer(self):
         """!Get the human layer number
 
-        This is the module number but shifted by one since the first layer is
-        layer 1.
+        Since, for the 2016 parameter mapping, a typo led to a dis-association between
+        the module number deduced from the ID number and the layer number, we have
+        to extract the layer number from the name of the parameter name as it appears
+        in the mapping. We look for '_L<digit>' and extract <digit> as the layer number.
         """
 
         m = Parameter.layer_number_pattern.match(self._name)
@@ -109,12 +111,16 @@ class Parameter:
     def axial(self):
         """!Get whether this Parameter represents a single axial sensor (True)
         or something else (False)
+
+        We have to check the name to see if 'axial' is in it.
         """
         return self.individual() and ('axial' in self.name)
 
     def stereo(self):
         """!Get whether this Parameter represents a single stereo sensor (True)
         or something else (False)
+
+        We have to check the name to see if 'stereo' is in it.
         """
         return self.individual() and ('stereo' in self.name)
 

--- a/python/hpsmc/alignment/_parameter.py
+++ b/python/hpsmc/alignment/_parameter.py
@@ -33,6 +33,7 @@ class Parameter:
     """
 
     idn_str_pattern = re.compile('^[12][12][123][0-9][0-9]$')
+    layer_number_pattern = re.compile('^.*_L([0-9]).*$')
 
     def __init__(self, idn, name, half, trans_rot, direction, mp_layer_id):
         self._id = int(idn)
@@ -66,9 +67,14 @@ class Parameter:
         """!Get the human layer number
 
         This is the module number but shifted by one since the first layer is
-        layer 1
+        layer 1.
         """
-        return self.module() + 1
+
+        m = Parameter.layer_number_pattern.match(self._name)
+        if m is None :
+            raise ValueError(f'Unable to deduce layer number from name {self.name}')
+
+        return int(m.group(1))
 
     def id(self):
         return self._id
@@ -104,13 +110,13 @@ class Parameter:
         """!Get whether this Parameter represents a single axial sensor (True)
         or something else (False)
         """
-        return self.individual() and (self._mp_layer_id % 2 == 0)
+        return self.individual() and ('axial' in self.name)
 
     def stereo(self):
         """!Get whether this Parameter represents a single stereo sensor (True)
         or something else (False)
         """
-        return self.individual() and (self._mp_layer_id % 2 == 1)
+        return self.individual() and ('stereo' in self.name)
 
     def front(self):
         """!True if Parameter is single sensor in front half, False otherwise"""

--- a/python/hpsmc/alignment/_pattern.py
+++ b/python/hpsmc/alignment/_pattern.py
@@ -61,7 +61,7 @@ class Pattern:
         """
         try:
             m = int(m)
-            if m < 0 or m > NUM_MODULES-1:
+            if m < 0 or m > Pattern.NUM_MODULES-1:
                 return NotImplemented
             return m
         except ValueError:
@@ -75,7 +75,7 @@ class Pattern:
         """
         try:
             layer = int(layer)
-            if layer < 1 or layer > NUM_MODULES:
+            if layer < 1 or layer > Pattern.NUM_MODULES:
                 return NotImplemented
             return layer
         except ValueError:

--- a/python/hpsmc/batch.py
+++ b/python/hpsmc/batch.py
@@ -91,12 +91,12 @@ class Batch:
 
         self.debug = cl.debug
 
-        for d in ['log_dir','sh_dir','run_dir'] :
+        for d in ['log_dir', 'sh_dir', 'run_dir']:
             # get the name of a dir from the command line and set
             # an attr in ourselves to the abspath of that value
             setattr(self, d, os.path.abspath(getattr(cl, d)))
             # create the directory if it doesn't exist
-            if not os.path.exists(getattr(self, d)) :
+            if not os.path.exists(getattr(self, d)):
                 logger.info(f'Creating {d} at {getattr(self,d)}')
                 os.makedirs(getattr(self, d))
 

--- a/python/hpsmc/batch.py
+++ b/python/hpsmc/batch.py
@@ -91,14 +91,14 @@ class Batch:
 
         self.debug = cl.debug
 
-        self.log_dir = cl.log_dir
-        self.sh_dir = cl.sh_dir
-        if not os.path.isabs(self.log_dir):
-            raise Exception('The log dir is not an abs path: %s' % self.log_dir)
-        ## \todo FIXME: This directory creation probably shouldn't happen here.
-        if not os.path.exists(self.log_dir):
-            logger.info('Creating log dir: %s' % self.log_dir)
-            os.makedirs(self.log_dir)
+        for d in ['log_dir','sh_dir','run_dir'] :
+            # get the name of a dir from the command line and set
+            # an attr in ourselves to the abspath of that value
+            setattr(self, d, os.path.abspath(getattr(cl, d)))
+            # create the directory if it doesn't exist
+            if not os.path.exists(getattr(self, d)) :
+                logger.info(f'Creating {d} at {getattr(self,d)}')
+                os.makedirs(getattr(self, d))
 
         self.check_output = cl.check_output
 
@@ -135,8 +135,6 @@ class Batch:
             self.config_files = list(map(os.path.abspath, cl.config_file))
         else:
             self.config_files = []
-
-        self.run_dir = cl.run_dir
 
         if cl.workflow:
             self.workflow = cl.workflow

--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -296,7 +296,7 @@ class Job(object):
             self.err = open(err_file, 'w')
 
         if cl.run_dir:
-            self.rundir = cl.run_dir
+            self.rundir = os.path.abspath(cl.run_dir)
 
         self.job_steps = cl.job_steps
         if self.job_steps is not None and self.job_steps < 1:

--- a/python/jobs/pede_job.py
+++ b/python/jobs/pede_job.py
@@ -35,7 +35,7 @@ if isinstance(job.input_files, str):
             # non-empty line, have destination be just the name of the file
             job.input_files[line] = os.path.basename(line)
 
-pede = PEDE(inputs=job.input_files.values() if 'no_copy' in job.params else job.input_files.keys())
+pede = PEDE(inputs=job.input_files.keys() if 'no_copy' in job.params else job.input_files.values())
 apply_res = ApplyPedeRes()
 construct_det = ConstructDetector()
 

--- a/scripts/hps-mc-construct-detector.in
+++ b/scripts/hps-mc-construct-detector.in
@@ -84,7 +84,7 @@ recompile() {
     export OLDPWD=${_old_pwd}
     return 1
   fi
-  if ! mvn ${MVN_OPTS}; then
+  if ! mvn install ${MVN_OPTS}; then
     echo "ERROR: Unable to recompile hps-java/detector-data"
     cd ${_pwd}
     export OLDPWD=${_old_pwd}
@@ -96,7 +96,7 @@ recompile() {
     export OLDPWD=${_old_pwd}
     return 1
   fi
-  if ! mvn ${MVN_OPTS}; then
+  if ! mvn install ${MVN_OPTS}; then
     echo "ERROR: Unable to recompile hps-java/distribution"
     cd ${_pwd}
     export OLDPWD=${_old_pwd}


### PR DESCRIPTION
this is necessary because the 2016 parameter mapping had a few typos in it when making the assignments which breaks the translation from ID number to layer number and Ax/St

## To Do
- [x] Format according to pycodestyle
- [x] Update function documentation
- [x] Check how this affects results when reading `res` file (and no mapping is available)

## What Did I Do??
Because the 2016 parameter mapping does not follow the convention set by the later 2019+ mapping allowing for simple arithmetic to calculate the layer number from the last two digits of the ID, I have switched the layer-number-deduction to simply extract it from the parameter name as it appears in the mapping. Similarly, I switched to deducing axial/stereo by looking for those words in the name rather than trying to deduce it from the ID.

Besides this necessary change, I also added a few more cosmetic updates.
- Add a new line when writing a note to a detector README to keep the notes spaced out.
- Convert all directory variables passed on the command line to `batch.py` into absolute paths and create them if necessary.
- Convert the run directory to absolute path in `job.py`
- Patch a bug in `pede_job.py` which switched the `no_copy` decision accidentally.
- Make sure any updated detector is _installed_ rather than just built by adding `install` to `hps-mc-construct-detector`