### PR TITLE
Revert changes to core classes that need to be tested

### DIFF
--- a/python/hpsmc/batch.py
+++ b/python/hpsmc/batch.py
@@ -91,14 +91,14 @@ class Batch:
 
         self.debug = cl.debug
 
-        for d in ['log_dir', 'sh_dir', 'run_dir']:
-            # get the name of a dir from the command line and set
-            # an attr in ourselves to the abspath of that value
-            setattr(self, d, os.path.abspath(getattr(cl, d)))
-            # create the directory if it doesn't exist
-            if not os.path.exists(getattr(self, d)):
-                logger.info(f'Creating {d} at {getattr(self,d)}')
-                os.makedirs(getattr(self, d))
+        self.log_dir = cl.log_dir
+        self.sh_dir = cl.sh_dir
+        if not os.path.isabs(self.log_dir):
+            raise Exception('The log dir is not an abs path: %s' % self.log_dir)
+        ## \todo FIXME: This directory creation probably shouldn't happen here.
+        if not os.path.exists(self.log_dir):
+            logger.info('Creating log dir: %s' % self.log_dir)
+            os.makedirs(self.log_dir)
 
         self.check_output = cl.check_output
 
@@ -135,6 +135,8 @@ class Batch:
             self.config_files = list(map(os.path.abspath, cl.config_file))
         else:
             self.config_files = []
+
+        self.run_dir = cl.run_dir
 
         if cl.workflow:
             self.workflow = cl.workflow

--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -296,7 +296,7 @@ class Job(object):
             self.err = open(err_file, 'w')
 
         if cl.run_dir:
-            self.rundir = os.path.abspath(cl.run_dir)
+            self.rundir = cl.run_dir
 
         self.job_steps = cl.job_steps
         if self.job_steps is not None and self.job_steps < 1:


### PR DESCRIPTION
These are changes to core hps-mc classes that were mixed into the unrelated PR #364 . They should be reverted, put onto a separate branch, and tested independently for verification. Specifically, the Auger, LSF, and Slurm batch bindings need to be verified to work properly with one or more examples.