### PR TITLE
patch run number for 2016 MC

### DIFF
--- a/examples/idm/job.json
+++ b/examples/idm/job.json
@@ -9,7 +9,7 @@
     "beam_energy": 2300.0,
     "num_electrons": 2500,
     "target_z": -4.3,
-    "run_number": 1162300,
+    "run_number": 7000,
     "detector": "HPS-PhysicsRun2016-Pass2",
     "steering_files": {
       "readout": "/org/hps/steering/readout/PhysicsRun2016TrigPairs1.lcsim",

--- a/examples/idm/vars.json
+++ b/examples/idm/vars.json
@@ -8,7 +8,7 @@
     "rmap": [3], 
     "rdmchi": [0.1],
     "mchi": [60, 90, 120, 150, 180, 210],
-    "run_number": [1162300],
+    "run_number": [7000],
     "detector": ["HPS-PhysicsRun2016-Pass2"],
     "steering_readout": ["/org/hps/steering/readout/PhysicsRun2016TrigPairs1.lcsim"],
     "steering_reco": ["/org/hps/steering/recon/PhysicsRun2016FullReconMC.lcsim"]


### PR DESCRIPTION
According to [this table on confluence](https://confluence.slac.stanford.edu/display/hpsg/MC+Run+Numbers), valid run numbers for 2016 MC are 7000-8999 (inclusive). This search was motivated by the fact that the current run number 1162300 causes the readout java job to error-out after unsuccessfully attempting to retrieve conditions.