### PR TITLE
set epsilon to 1 everywhere in iDM MG/ME generator

### DIFF
--- a/generators/madgraph5/src/idm/Cards/param_card.dat
+++ b/generators/madgraph5/src/idm/Cards/param_card.dat
@@ -42,7 +42,7 @@ Block gaugemass
 Block hidden 
     1 1.000000e+00 # Map 
     2 2.000000e+02 # MHS 
-    3 1.000000e-02 # epsilon 
+    3 1.000000e+00 # epsilon 
     4 1.000000e-09 # kap 
     5 1.279000e+02 # aXM1 
 

--- a/generators/madgraph5/src/idm/Cards/param_card_default.dat
+++ b/generators/madgraph5/src/idm/Cards/param_card_default.dat
@@ -42,7 +42,7 @@ Block gaugemass
 Block hidden 
     1 1.000000e+00 # Map 
     2 2.000000e+02 # MHS 
-    3 1.000000e-02 # epsilon 
+    3 1.000000e+00 # epsilon 
     4 1.000000e-09 # kap 
     5 1.279000e+02 # aXM1 
 

--- a/generators/madgraph5/src/idm/bin/internal/ufomodel/README.md
+++ b/generators/madgraph5/src/idm/bin/internal/ufomodel/README.md
@@ -72,7 +72,7 @@ Map | hidden | 1 | dark photon mass
 WAp | decay | 8.252e-4 | dark photon decay width
 Wchi2 | decay | 1e-3 | heavier DM decay width
 MHS | hidden | 200 | dark higgs mass (can ignore)
-epsilon | hidden | 1e-2 | kinetic mixing (can ignore / want to study independently)
+epsilon | hidden | 1 | kinetic mixing (can ignore / want to study independently)
 kap | hidden | 1e-9 | dark higgs quartic (can ignore)
 aXM1 | hidden | 1.279e2 | $1/\alpha_D$ (set to $1/\alpha_{EW}$)
 GAN | frblock | 3.028177e-1 | nucleus and standard photon coupling

--- a/generators/madgraph5/src/idm/bin/internal/ufomodel/param_card.dat
+++ b/generators/madgraph5/src/idm/bin/internal/ufomodel/param_card.dat
@@ -103,7 +103,7 @@ Block GAUGEMASS
 Block HIDDEN 
     1 1.000000e+00 # Map 
     2 2.000000e+02 # MHS 
-    3 1.000000e-02 # epsilon 
+    3 1.000000e+00 # epsilon 
     4 1.000000e-09 # kap 
     5 1.279000e+02 # aXM1 
 

--- a/generators/madgraph5/src/idm/bin/internal/ufomodel/parameters.py
+++ b/generators/madgraph5/src/idm/bin/internal/ufomodel/parameters.py
@@ -157,7 +157,7 @@ MHS = Parameter(name = 'MHS',
 epsilon = Parameter(name = 'epsilon',
                     nature = 'external',
                     type = 'real',
-                    value = 0.01,
+                    value = 1.00,
                     texname = '\\epsilon',
                     lhablock = 'HIDDEN',
                     lhacode = [ 3 ])


### PR DESCRIPTION
since epsilon also affects the decay length of chi2, we delay including it in the chain until we are studying the vertex displacement affects downstream in the analysis pipeline. Having $\epsilon=1$ in the model makes it easier to include it later since we don't have to remember what its value was before.