### PR TITLE
A few more alignment patches

### DIFF
--- a/python/hpsmc/alignment/_apply.py
+++ b/python/hpsmc/alignment/_apply.py
@@ -73,10 +73,10 @@ class _DetectorEditor(Component):
                 # deduce iter value, using iter0 if there is no iter suffix
                 matches = re.search('.*iter([0-9]*)', self.detector)
                 if matches is None:
-                    raise ValueError('No "_iterN" suffix on detector name.')
+                    raise ValueError('No "iterN" suffix on detector name.')
                 else:
                     i = int(matches.group(1))
-                    self.next_detector = self.detector.replace(f'_iter{i}', f'_iter{i+1}')
+                    self.next_detector = self.detector.replace(f'iter{i}', f'iter{i+1}')
 
             self.logger.info(f'Creating new detector named "{self.next_detector}"')
         else:

--- a/python/hpsmc/alignment/_parameter.py
+++ b/python/hpsmc/alignment/_parameter.py
@@ -32,7 +32,7 @@ class Parameter:
         true if parameter is floating, false otherwise
     """
 
-    idn_str_pattern = re.compile('^[12][12][123][0-9][0-9]$')
+    idn_str_pattern = re.compile('^[12][123][123][0-9][0-9]$')
     layer_number_pattern = re.compile('^.*_L([0-9]).*$')
 
     def __init__(self, idn, name, half, trans_rot, direction, mp_layer_id):
@@ -114,7 +114,7 @@ class Parameter:
 
         We have to check the name to see if 'axial' is in it.
         """
-        return self.individual() and ('axial' in self.name)
+        return self.individual() and ('axial' in self._name)
 
     def stereo(self):
         """!Get whether this Parameter represents a single stereo sensor (True)
@@ -122,7 +122,7 @@ class Parameter:
 
         We have to check the name to see if 'stereo' is in it.
         """
-        return self.individual() and ('stereo' in self.name)
+        return self.individual() and ('stereo' in self._name)
 
     def front(self):
         """!True if Parameter is single sensor in front half, False otherwise"""


### PR DESCRIPTION
- don't require `_` in iterN suffix of detector, allows me to use `-` instead which I prefer
- patch type in axial/stereo deduction within `Parameter` which was referring to `self.name` instead of `self._name`
- update ID number regex to allow `3` in the second digit (used for structure rotations in 2016)