### PR TITLE
add slic parameter to disable particle table

### DIFF
--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -29,6 +29,8 @@ class SLIC(Component):
         ## To be set from config or install dir
         self.detector_dir = None
         ## Optionally disable loading of the particle table shipped with slic
+        ## Note: This should not be used with a General Particle Source since the GPS
+        ## in slic requires the particle table to function.
         self.disable_particle_table = False
 
         Component.__init__(self,

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -16,7 +16,7 @@ class SLIC(Component):
     """!
     Run the SLIC Geant4 simulation.
 
-    Optional parameters are: **nevents**, **macros**, **run_number** \n
+    Optional parameters are: **nevents**, **macros**, **run_number**, **disable_particle_table** \n
     Required parameters are: **detector** \n
     Required configurations are: **slic_dir**, **detector_dir**
     """
@@ -28,6 +28,8 @@ class SLIC(Component):
         self.run_number = None
         ## To be set from config or install dir
         self.detector_dir = None
+        ## Optionally disable loading of the particle table shipped with slic
+        self.disable_particle_table = False
 
         Component.__init__(self,
                            name='slic',
@@ -54,11 +56,12 @@ class SLIC(Component):
         if self.run_number is not None:
             args.extend(["-m", "run_number.mac"])
 
-        tbl = self.__particle_tbl()
-        if os.path.exists(tbl):
-            args.extend(["-P", tbl])
-        else:
-            raise Exception('SLIC particle.tbl does not exist: %s' % tbl)
+        if not self.disable_particle_table:
+            tbl = self.__particle_tbl()
+            if os.path.exists(tbl):
+                args.extend(["-P", tbl])
+            else:
+                raise Exception('SLIC particle.tbl does not exist: %s' % tbl)
 
         if len(self.macros):
             # args = []
@@ -113,7 +116,7 @@ class SLIC(Component):
         Optional parameters are: **nevents**, **macros**, **run_number**
         @return  list of optional parameters
         """
-        return ['nevents', 'macros', 'run_number']
+        return ['nevents', 'macros', 'run_number', 'disable_particle_table']
 
     def required_parameters(self):
         """!


### PR DESCRIPTION
As pointed out here: https://github.com/slaclab/slic/issues/101 , the particle table (when loaded) can cause excessive printouts for certain simulation samples without any observed benefit. This PR introduces a new optional parameter for the `SLIC` hps-mc component allowing users to disable the loading of the particle table if they so wish. The default is still to load the particle table in order to avoid breaking any current configurations (although I strongly suspect loading the particle table has no effect on any of the samples HPS is studying).