### PR TITLE
Disable particle table advice

### DIFF
--- a/examples/idm/job.json
+++ b/examples/idm/job.json
@@ -11,6 +11,7 @@
     "target_z": -4.3,
     "run_number": 7000,
     "detector": "HPS-PhysicsRun2016-Pass2",
+    "disable_particle_table": true,
     "steering_files": {
       "readout": "/org/hps/steering/readout/PhysicsRun2016TrigPairs1.lcsim",
       "recon": "/org/hps/steering/recon/PhysicsRun2016FullReconMC.lcsim"

--- a/examples/idm/job.json.tmpl
+++ b/examples/idm/job.json.tmpl
@@ -11,6 +11,7 @@
     "run_number": {{ run_number }},
     "seed": {{job_id + 879482}}, 
     "detector": "{{ detector }}",
+    "disable_particle_table": true,
     "filter_no_cuts": true,
     "steering_files": {
         "readout": "{{ steering_readout }}",

--- a/examples/simp/job.json
+++ b/examples/simp/job.json
@@ -11,6 +11,7 @@
     "run_number": 1194550,
     "seed": 879483,
     "detector": "HPS-v2019-3pt7GeV",
+    "disable_particle_table": true,
     "filter_no_cuts": true,
     "steering_files": {
         "readout": "/org/hps/steering/readout/TriggerTuning2021TrigPulse.lcsim",

--- a/examples/simp/job.json.tmpl
+++ b/examples/simp/job.json.tmpl
@@ -11,6 +11,7 @@
     "run_number": {{ run_number }},
     "seed": {{job_id + 879482}}, 
     "detector": "{{ detector }}",
+    "disable_particle_table": true,
     "filter_no_cuts": true,
     "steering_files": {
         "readout": "{{ steering_readout }}",

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -19,6 +19,15 @@ class SLIC(Component):
     Optional parameters are: **nevents**, **macros**, **run_number**, **disable_particle_table** \n
     Required parameters are: **detector** \n
     Required configurations are: **slic_dir**, **detector_dir**
+
+    Besides setting the number of events, detector, and run number it is common to disable
+    loading of the particle table. The loaded particle table creates particles that have
+    decay widths but the actual decay process is not defined within Geant4; thus, if one
+    of the particles that is created happens to trigger a decay within the Geant4 world,
+    it will create a Segmentation fault when trying to access the uncreated decay process.
+
+    The particle table loading is helpful for the General Particle Source (GPS) since it
+    needs to have these extra particles defined.
     """
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
I put the reasoning in the code comment as well, but in order to have it here:

The loaded particle table creates particles that have
    decay widths but the actual decay process is not defined within Geant4; thus, if one
    of the particles that is created happens to trigger a decay within the Geant4 world,
    it will create a Segmentation fault when trying to access the uncreated decay process.
    The particle table loading is helpful for the General Particle Source (GPS) since it
    needs to have these extra particles defined.