### PR TITLE
New Updated for SQLite Local Copying for 10% Production

### DIFF
--- a/python/hpsmc/component.py
+++ b/python/hpsmc/component.py
@@ -66,7 +66,9 @@ class Component(object):
         self.logger = logging.getLogger("{}.{}".format(__name__, self.__class__.__name__))
 
     def cmd_line_str(self):
-        cl = [self.command]
+        cl = []
+        if self.command: 
+            cl.append(self.command)
         cl.extend(self.cmd_args())
         return ' '.join(cl)
 

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -157,6 +157,57 @@ class SLIC(Component):
         return proc.returncode
 
 
+
+class SQLiteProc(Component):
+    """!
+    Copy the SQLite database file to the desired location.
+    """
+
+    def __init__(self, **kwargs):
+        """!
+        Initialize SQLiteProc to copy the SQLite file.
+        """
+
+        self.source_file = '/w/hallb-scshelf2102/hps/zshi/swiftjob/SQLite/LocalTest/hps_conditions_2025_03_06.sqlite'
+        self.destination_file = './hps_conditions_2025_03_06.sqlite'  # Modify this as needed
+
+       
+        # Ensure to call the parent constructor properly
+        Component.__init__(self, name='sqlite_file_copy', **kwargs)
+
+
+    def cmd_args(self):
+        """!
+        Return dummy command arguments to satisfy the parent class.
+        """
+        cmd_args = ["(no-command-needed)"]
+
+        if not all(isinstance(arg, str) for arg in cmd_args):
+            raise ValueError("All arguments must be strings.")
+      #  return ["(no-command-needed)"]
+        return ['--source', self.source_file, '--destination', self.destination_file]
+
+    def execute(self, log_out, log_err):
+        """!
+        Execute the file copy operation.
+        """
+        
+        try:
+            # Copy the file
+          
+            self.logger.info(f"Copying file from {self.source_file} to {self.destination_file}")
+            shutil.copy(self.source_file, self.destination_file)
+
+            # Log success
+            self.logger.info(f"Successfully copied file to {self.destination_file}")
+
+            return 0  # Success code
+
+        except Exception as e:
+            self.logger.error(f"Error during file copy: {e}")
+            return 1  # Error code
+
+
 class JobManager(Component):
     """!
     Run the hps-java JobManager class.

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -167,10 +167,24 @@ class SQLiteProc(Component):
         """!
         Initialize SQLiteProc to copy the SQLite file.
         """
+        self.source_file = kwargs.get('source_file')    
+        self.destination_file = kwargs.get('destination_file')
+        
+        #You can set this under for .hpsmc file to point to a specific local database. For me I used the following in .hpsmc 
+        #[EvioToLcio]
+        #hps_java_bin_jar = /home/zshi/.m2/repository/org/hps/hps-distribution/5.2.2-SNAPSHOT/hps-distribution-5.2.2-SNAPSHOT-bin.jar
+        #java_args = -Xmx3g -XX:+UseSerialGC -Dorg.sqlite.tmpdir=/w/hallb-scshelf2102/hps/zshi/swiftjob/SQLite/LocalTest/tmp/ -Dorg.hps.conditions.url=jdbc:sqlite:hps_conditions_2025_03_06.sqlite
+        #[SQLiteProc]
+        #source_file = /w/hallb-scshelf2102/hps/zshi/swiftjob/SQLite/LocalTest/hps_conditions_2025_03_06.sqlite
+        #destination_file = ./hps_conditions_2025_03_06.sqlite
 
-        self.source_file = '/w/hallb-scshelf2102/hps/zshi/swiftjob/SQLite/LocalTest/hps_conditions_2025_03_06.sqlite'
-        self.destination_file = './hps_conditions_2025_03_06.sqlite'  # Modify this as needed
 
+        if self.source_file is not None:
+            self.logger.debug("Setting SQLite local copy source file from config: %s" + self.source_file) 
+            args.append(self.source_file)
+        if self.destination_file is not None:
+            self.logger.debug('Setting Job Destination file from config: %s' % self.destination_file)
+            args.append('-Dorg.hps.conditions.url=%s' % self.destination_file)
        
         # Ensure to call the parent constructor properly
         Component.__init__(self, name='sqlite_file_copy', **kwargs)

--- a/python/jobs/data_cnv_10_percent_job.py
+++ b/python/jobs/data_cnv_10_percent_job.py
@@ -1,0 +1,16 @@
+"""!
+@file data_cnv_job.py
+
+Convert EVIO to LCIO and then process with HPSTR to produce a recon tuple.
+"""
+from hpsmc.tools import EvioToLcio, HPSTR, SQLiteProc
+
+job.description = 'EVIO converter'
+
+sqlite = SQLiteProc()
+
+cnv = EvioToLcio(steering='recon')
+
+tuple = HPSTR(run_mode=1, cfg='recon')
+
+job.add([sqlite, cnv, tuple])


### PR DESCRIPTION
This is a fixed the previous improper pull request for SQLite: https://github.com/JeffersonLab/hps-mc/pull/428#

I modified the tools.py to add the class named SQLiteProc to copy a local SQLite snapshot that is saved on my jlab ifarm location: /w/hallb-scshelf2102/hps/zshi/swiftjob/SQLite/LocalTest/hps_conditions_2025_03_06.sqlite. I also added the workflow named data_cnv_10_percent_job.py for a workflow to submit this swif2 jobs. Only 3 files in total are modifed. 

This pull request is in response to the JIRA ticket for SQLite on SLAC confluence: https://jira.slac.stanford.edu/login-interim.jsp?os_destination=%2Fbrowse%2FHPSANA-56&permissionViolation=true


