### PR TITLE
Making matching tighter for alignment parameters

### DIFF
--- a/python/hpsmc/alignment/_apply.py
+++ b/python/hpsmc/alignment/_apply.py
@@ -163,7 +163,7 @@ class _DetectorEditor(Component):
 
                     line_edited = False
                     for i in parameter_set:
-                        if str(i) in line:
+                        if f'name="{i}"' in line:
                             # the parameter with ID i is being set on this line
                             self.logger.debug(f'Changing parameter {i}')
                             f.write(_change_xml_value(


### PR DESCRIPTION
It can (and has) happen that the millepede parameters appear in one of the floating point values, and as a result the desired variations gets applied to a different millepede parameter than desired. This happens because the previous matching only checks if the millepede parameter exists in the line (which contains the floating point changes to that parameter). 