### PR TITLE
This fixes the bugs mentioned in iss444:

### DIFF
--- a/python/hpsmc/job.py
+++ b/python/hpsmc/job.py
@@ -295,7 +295,7 @@ class Job(object):
             if not os.path.isabs(out_file):
                 out_file = os.path.abspath(out_file)
                 logger.info('Job output will be written to: %s' % out_file)
-            self.out = open(out_file, 'w')
+            self.component_out = open(out_file, 'w')
 
         # Set file for stderr from components
         if cl.err:
@@ -303,7 +303,7 @@ class Job(object):
             if not os.path.isabs(err_file):
                 err_file = os.path.abspath(err_file)
                 logger.info('Job error will be written to: %s' % err_file)
-            self.err = open(err_file, 'w')
+            self.component_err = open(err_file, 'w')
 
         if cl.run_dir:
             self.rundir = os.path.abspath(cl.run_dir)
@@ -335,6 +335,8 @@ class Job(object):
                 # Load data from a JSON file with a single job definition.
                 logger.info('Loading job parameters from file: %s' % self.param_file)
                 params = json.loads(open(self.param_file, 'r').read())
+                if isinstance(params, list):
+                    params = params[0]
                 if not isinstance(params, dict):
                     raise Exception('Job ID must be provided when running from a job store.')
 

--- a/python/hpsmc/tools.py
+++ b/python/hpsmc/tools.py
@@ -458,7 +458,7 @@ class ProcessMiniDst(Component):
         self.input_file = None
         self.minidst_args = None
         # Ensure to call the parent constructor properly
-        Component.__init__(self, name='makeminidst',
+        Component.__init__(self, name='make_mini_dst',
                            command='make_mini_dst',
                            description='Create the MiniDST ROOT file',
                            output_ext='.root',
@@ -504,7 +504,8 @@ class ProcessMiniDst(Component):
         """! Adjust names of output files."""
         if self.outputs is None:
             f, ext = os.path.splitext(self.input_files()[0])
-            self.outputs = f"{f}.root"
+            self.outputs = f"{f}_minidst.root"
+            print(f"Set outputs to: {self.outputs}")
 
         return self.outputs
 
@@ -515,16 +516,16 @@ class ProcessMiniDst(Component):
         """
         args = []
 
-        print("===== Make MiniDST with input files: ", end="")
+        print("===== Make MiniDST with input files: ", end=" ")
         for i in range(len(self.input_files())):
             print(f"{self.input_files()[i]}", end=", ")
-        print(f" -> {self.output_files()}")
+        print(f" ==> {self.output_files()}")
 
-        args.extend(self.minidst_args)
+        if self.minidst_args is not None:
+            args.extend(self.minidst_args)
 
-        args.extend(['-o', self.output_files()[0]])
+        args.extend(['-o', self.output_files()])
         args.extend(self.input_files())
-
         return args
 
 


### PR DESCRIPTION
The output log and error log files are not filled for command line jobs. This is a simple error where the opened file handle is assigned to self.out instead of self.component_out.

When running a single job, it is convenient for the script to run the first job in a jobs.json file, instead of having to make a specific job.json file without the [] brackets. Simple solution: check if the json is a list, and if so, use the first element from this list.

The ProcessMiniDst needs a few tweaks to run properly.